### PR TITLE
Fixed the ping message

### DIFF
--- a/Src/Common/Websockets/BybitWebSocket.cs
+++ b/Src/Common/Websockets/BybitWebSocket.cs
@@ -182,7 +182,7 @@ namespace bybit.net.api.Websockets
                 await Task.Delay(TimeSpan.FromSeconds(10), token);
                 if (this.handler.State == WebSocketState.Open)
                 {
-                    await SendAsync("ping", CancellationToken.None);
+                    await SendAsync("{\"op\": \"ping\"}", CancellationToken.None);
                     await Console.Out.WriteLineAsync("ping sent");
                 }
             }


### PR DESCRIPTION
The format of the sent ping message was incorrect, which prevented the functionality that keeps the socket open from working properly.