### PR TITLE
Fiexd the "The key is already added" exception when GetInstrumentInfo is called.

### DIFF
--- a/Src/Common/ApiServiceImp/BybitMarketDataService.cs
+++ b/Src/Common/ApiServiceImp/BybitMarketDataService.cs
@@ -180,7 +180,6 @@ namespace bybit.net.api.ApiServiceImp
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("status", status?.Status),
-                ("symbol", symbol),
                 ("baseCoin", baseCoin),
                 ("limit", limit),
                 ("cursor", cursor)


### PR DESCRIPTION
Currently when you send the request with GetInstrumentInfo you call an "AddOptionalParameters" method that passes a parameter that already existed (the symbol of the coin ex: "BTCUSDT") so there was an unhandeled exception thrown when you call the GetInstrumentInfo - the key is already added. Now i removed the passing of the symbol from the params since its already added in the query and this fixed the problem. Also i noticed that you dont have unit tests for that method so if you agree with the changes i could do that too.