### PR TITLE
 [RELEASE] bybit.net.api v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitAccountService.SetDeltaNeutralMode(...)` for `POST /v5/account/set-delta-mode`.
 - Added `BybitAccountService.GetTradeInfoForAnalysis(...)` for `GET /v5/account/trade-info-for-analysis`.
 - Added `BybitAccountService.GetTransferableAmount(...)` for `GET /v5/account/withdrawal`.
+- Added `BybitAssetService.GetFundingAccountTransactionHistory(...)` for `GET /v5/asset/fundinghistory`.
+- Added `BybitAssetService.GetPortfolioMarginInfo(...)` for `GET /v5/asset/portfolio-margin`.
+- Added `BybitAssetService.GetTotalMembersAssets(...)` for `GET /v5/asset/total-members-assets`.
+- Added `BybitAssetService.GetAssetOverview(...)` for `GET /v5/asset/asset-overview`.
+- Added `BybitAssetService.GetWithdrawalAddressList(...)` for `GET /v5/asset/withdraw/query-address`.
+- Added small balance convert methods for `GET /v5/asset/covert/small-balance-list`, `POST /v5/asset/covert/get-quote`, `POST /v5/asset/covert/small-balance-execute`, and `GET /v5/asset/covert/small-balance-history`.
+- Added fiat convert methods for `GET /v5/fiat/balance-query`, `GET /v5/fiat/query-coin-list`, `POST /v5/fiat/quote-apply`, `POST /v5/fiat/trade-execute`, `GET /v5/fiat/trade-query`, `GET /v5/fiat/query-trade-history`, and `GET /v5/fiat/reference-price`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
+- Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
+- Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 
 ### Changed
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
 - Updated `BybitAccountService.ManualRepay(...)` to support the documented `repaymentType` parameter.
 - Updated `BybitAccountService.ManualBorrow(...)`, `ManualRepay(...)`, and `SetAccountMarginMode(...)` to return typed models instead of raw JSON strings.
+- Updated `BybitAssetService.GetTransferableCoin(...)`, `CreateInternalTransfer(...)`, and `CreateUniversalTransfer(...)` to send `fromAccountType`.
+- Updated `BybitAssetService.GetInternalTransferRecords(...)` and `GetUniversalTransferRecords(...)` to send `status` instead of `transferStatus`.
+- Updated `BybitAssetService.GetAssetAllowedDepositInfo(...)` to use the public endpoint flow instead of signed authentication.
+- Updated `BybitAssetService.GetDeliveryRecord(...)`, `GetCoinExchangeRecords(...)`, and `GetAssetUsdcSettlement(...)` to return typed response models.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.
+- Removed the stale `GetAssetDeliveryRecords(...)` implementation that pointed to the coin exchange history route instead of the active delivery endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,15 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added easy earn methods for `GET /v5/earn/apr-history`, `GET /v5/earn/hourly-yield`, `GET /v5/earn/yield`, and `POST /v5/earn/position/modify`.
 - Added fixed-term earn methods for `GET /v5/earn/fixed-term/product`, `POST /v5/earn/fixed-term/place-order`, `GET /v5/earn/fixed-term/order`, `GET /v5/earn/fixed-term/position`, `POST /v5/earn/fixed-term/redeem`, and `POST /v5/earn/fixed-term/position/auto-invest`.
 - Added token earn methods for `GET /v5/earn/token/product`, `POST /v5/earn/token/place-order`, `GET /v5/earn/token/order`, `GET /v5/earn/token/position`, `GET /v5/earn/token/yield`, `GET /v5/earn/token/hourly-yield`, and `GET /v5/earn/token/history-apr`.
+- Added `BybitLendingService.RepayInsLoan(...)` for `POST /v5/ins-loan/repay-loan`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
 - Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
 - Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
 - Added typed earn response models for shared earn, fixed-term earn, and BYUSDT token earn endpoints.
+- Added typed lending response models for institutional lending and legacy C2C lending endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
 - Added earn endpoint tests covering shared earn, fixed-term, and token endpoint routing and payload mapping.
+- Added lending endpoint tests covering current OTC routes, public access behavior, and corrected legacy lending routes.
 
 ### Changed
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
@@ -55,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitEarnService.GetProductInfo(...)`, `PlaceEarnOrder(...)`, `GetEarnOrderHistory(...)`, and `GetStakedPosition(...)` to return typed models instead of raw JSON strings.
 - Updated `BybitEarnService.GetEarnOrderHistory(...)` to support the documented `productId`, `startTime`, `endTime`, `limit`, and `cursor` parameters.
 - Updated `BybitEarnService` with public constructors so public earn endpoints can be used without API credentials.
+- Updated `BybitLendingService.GetInsLoanOrders(...)` and `GetInsLoanRepayOrders(...)` to use the current OTC routes instead of the incorrect `ensure-tokens-convert` placeholder route.
+- Updated `BybitLendingService.GetInsLoanInfo(...)` and `GetInsMarginCoinInfo(...)` to use the public endpoint flow and return typed models.
+- Updated `BybitLendingService` legacy C2C methods to use typed models and corrected routes for `redeem-cancel` and `history-order`.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitNewCryptoLoanService.GetMaxLoanAmount(...)` for `POST /v5/crypto-loan-common/max-loan`.
 - Added `BybitNewCryptoLoanService.RenewFixedLoan(...)` for `POST /v5/crypto-loan-fixed/renew`.
 - Added `BybitNewCryptoLoanService.GetRenewOrderInfoFixed(...)` for `GET /v5/crypto-loan-fixed/renew-info`.
+- Added `BybitP2PService.ReviewSellerCancelOrderApply(...)` for `POST /v5/p2p/order/buyer/examine/sellerCancelOrderApply`.
+- Added `BybitP2PService.UploadChatFile(...)` for `POST /v5/p2p/oss/upload_file`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
@@ -50,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed lending response models for institutional lending and legacy C2C lending endpoints.
 - Added typed market response models for recent trades, open interest, insurance pool, delivery price, index price components, ADL alerts, and fee group info.
 - Added typed new crypto loan request and response models for active common, flexible, and fixed crypto loan endpoints.
+- Added typed P2P response models for active P2P ad, order, chat, account, and payment endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
@@ -83,6 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitNewCryptoLoanService.BorrowFlexibleLoan(...)` to send documented `currency` and `amount` collateral fields.
 - Updated `BybitNewCryptoLoanService.CreateBorrowOrderFixed(...)` to support the documented `repayType` parameter.
 - Updated `BybitNewCryptoLoanService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
+- Updated `BybitP2PService.GetAllOrders(...)` and `GetPendingOrders(...)` to send `side` as a single integer instead of an array.
+- Updated `BybitP2PService` methods to return typed P2P response models instead of raw JSON strings.
+- Updated signed REST transport to support multipart form-data requests.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitP2PService.ReviewSellerCancelOrderApply(...)` for `POST /v5/p2p/order/buyer/examine/sellerCancelOrderApply`.
 - Added `BybitP2PService.UploadChatFile(...)` for `POST /v5/p2p/oss/upload_file`.
 - Added `BybitRFQService.AcceptOtherQuote(...)` for `POST /v5/rfq/accept-other-quote`.
+- Added Spot Margin UTA methods for currency data, coin state, position tiers, max borrowable amount, repayment available amount, auto repay mode, fixed-rate borrow, fixed-rate renew, fixed-rate order/contract info, and liability endpoints.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
@@ -98,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitPositionService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 - Updated `BybitRateLimitService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 - Updated RFQ quote request legs to support the documented `price` field.
+- Updated Spot Margin UTA switch-mode to use `POST`, corrected `SpotMarginMode` values, changed status lookup to `GET`, and added optional `currency` support to set leverage.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added affiliate endpoint tests covering the affiliate date-filter query mapping and typed response mapping.
 
 ### Changed
+- Updated library, test, and example project target frameworks to .NET 10 LTS.
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
 - Updated `BybitAccountService.ManualRepay(...)` to support the documented `repaymentType` parameter.
 - Updated `BybitAccountService.ManualBorrow(...)`, `ManualRepay(...)`, and `SetAccountMarginMode(...)` to return typed models instead of raw JSON strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitP2PService.UploadChatFile(...)` for `POST /v5/p2p/oss/upload_file`.
 - Added `BybitRFQService.AcceptOtherQuote(...)` for `POST /v5/rfq/accept-other-quote`.
 - Added Spot Margin UTA methods for currency data, coin state, position tiers, max borrowable amount, repayment available amount, auto repay mode, fixed-rate borrow, fixed-rate renew, fixed-rate order/contract info, and liability endpoints.
+- Added `BybitSpreadTradingService.GetSpreadMaxOrderQty(...)` for `GET /v5/spread/max-qty`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added fixed-term earn methods for `GET /v5/earn/fixed-term/product`, `POST /v5/earn/fixed-term/place-order`, `GET /v5/earn/fixed-term/order`, `GET /v5/earn/fixed-term/position`, `POST /v5/earn/fixed-term/redeem`, and `POST /v5/earn/fixed-term/position/auto-invest`.
 - Added token earn methods for `GET /v5/earn/token/product`, `POST /v5/earn/token/place-order`, `GET /v5/earn/token/order`, `GET /v5/earn/token/position`, `GET /v5/earn/token/yield`, `GET /v5/earn/token/hourly-yield`, and `GET /v5/earn/token/history-apr`.
 - Added `BybitLendingService.RepayInsLoan(...)` for `POST /v5/ins-loan/repay-loan`.
+- Added `BybitMarketDataService.GetRpiOrderbook(...)` for `GET /v5/market/rpi_orderbook`.
+- Added `BybitMarketDataService.GetAdlAlert(...)` for `GET /v5/market/adlAlert`.
+- Added `BybitMarketDataService.GetIndexPriceComponents(...)` for `GET /v5/market/index-price-components`.
+- Added `BybitMarketDataService.GetFeeGroupInfo(...)` for `GET /v5/market/fee-group-info`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
@@ -41,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
 - Added typed earn response models for shared earn, fixed-term earn, and BYUSDT token earn endpoints.
 - Added typed lending response models for institutional lending and legacy C2C lending endpoints.
+- Added typed market response models for recent trades, open interest, insurance pool, delivery price, index price components, ADL alerts, and fee group info.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
@@ -65,6 +70,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitLendingService` legacy C2C methods to use typed models and corrected routes for `redeem-cancel` and `history-order`.
 - Updated `BybitAffiliateService.GetAffiliateUserList(...)` to support the documented `startDate` and `endDate` parameters.
 - Updated `BybitAffiliateService.GetAffiliateUserList(...)` and `GetAffiliateUserInfo(...)` to return typed models instead of raw JSON strings.
+- Updated `BybitMarketDataService` public endpoints to return typed `GeneralResponse<T>` models instead of raw JSON strings.
+- Updated `BybitMarketDataService.GetInstrumentInfo(...)` to support the documented `symbolType` parameter.
+- Updated `BybitMarketDataService.GetMarketOrderbook(...)` to require the documented `symbol` parameter.
+- Updated market kline methods to support omitted `category` where the V5 docs define a default.
+- Updated `BybitMarketDataService.GetMarketHistoricalVolatility(...)` to support `quoteCoin` and the documented integer `period` request shape.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitRFQService.AcceptOtherQuote(...)` for `POST /v5/rfq/accept-other-quote`.
 - Added Spot Margin UTA methods for currency data, coin state, position tiers, max borrowable amount, repayment available amount, auto repay mode, fixed-rate borrow, fixed-rate renew, fixed-rate order/contract info, and liability endpoints.
 - Added `BybitSpreadTradingService.GetSpreadMaxOrderQty(...)` for `GET /v5/spread/max-qty`.
+- Added lightweight `BybitAlphaService` coverage for the V5 Alpha trade endpoints.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitMarketDataService.GetAdlAlert(...)` for `GET /v5/market/adlAlert`.
 - Added `BybitMarketDataService.GetIndexPriceComponents(...)` for `GET /v5/market/index-price-components`.
 - Added `BybitMarketDataService.GetFeeGroupInfo(...)` for `GET /v5/market/fee-group-info`.
+- Added `BybitNewCryptoLoanService.GetMaxLoanAmount(...)` for `POST /v5/crypto-loan-common/max-loan`.
+- Added `BybitNewCryptoLoanService.RenewFixedLoan(...)` for `POST /v5/crypto-loan-fixed/renew`.
+- Added `BybitNewCryptoLoanService.GetRenewOrderInfoFixed(...)` for `GET /v5/crypto-loan-fixed/renew-info`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
@@ -46,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed earn response models for shared earn, fixed-term earn, and BYUSDT token earn endpoints.
 - Added typed lending response models for institutional lending and legacy C2C lending endpoints.
 - Added typed market response models for recent trades, open interest, insurance pool, delivery price, index price components, ADL alerts, and fee group info.
+- Added typed new crypto loan request and response models for active common, flexible, and fixed crypto loan endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
@@ -75,6 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitMarketDataService.GetMarketOrderbook(...)` to require the documented `symbol` parameter.
 - Updated market kline methods to support omitted `category` where the V5 docs define a default.
 - Updated `BybitMarketDataService.GetMarketHistoricalVolatility(...)` to support `quoteCoin` and the documented integer `period` request shape.
+- Updated `BybitNewCryptoLoanService` with public constructors so public new crypto loan endpoints can be used without API credentials.
+- Updated `BybitNewCryptoLoanService.BorrowFlexibleLoan(...)` to send documented `currency` and `amount` collateral fields.
+- Updated `BybitNewCryptoLoanService.CreateBorrowOrderFixed(...)` to support the documented `repayType` parameter.
+- Updated `BybitNewCryptoLoanService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - Unreleased
+## [1.3.0] - 2026-04-22
 
 ### Added
 - Added `BybitAccountService.GetAccountInstrumentsInfo(...)` for `GET /v5/account/instruments-info`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitAssetService.GetWithdrawalAddressList(...)` for `GET /v5/asset/withdraw/query-address`.
 - Added small balance convert methods for `GET /v5/asset/covert/small-balance-list`, `POST /v5/asset/covert/get-quote`, `POST /v5/asset/covert/small-balance-execute`, and `GET /v5/asset/covert/small-balance-history`.
 - Added fiat convert methods for `GET /v5/fiat/balance-query`, `GET /v5/fiat/query-coin-list`, `POST /v5/fiat/quote-apply`, `POST /v5/fiat/trade-execute`, `GET /v5/fiat/trade-query`, `GET /v5/fiat/query-trade-history`, and `GET /v5/fiat/reference-price`.
+- Added `BybitBrokerService.GetBrokerAccountInfo()` for `GET /v5/broker/account-info`.
+- Added `BybitBrokerService.GetBrokerSubMemberDepositRecords(...)` for `GET /v5/broker/asset/query-sub-member-deposit-record`.
+- Added `BybitBrokerService.GetBrokerAllRateLimits(...)` for `GET /v5/broker/apilimit/query-all`.
+- Added `BybitBrokerService.GetBrokerRateLimitCap()` for `GET /v5/broker/apilimit/query-cap`.
+- Added `BybitBrokerService.SetBrokerRateLimit(...)` for `POST /v5/broker/apilimit/set`.
+- Added `BybitBrokerService.GetBrokerVoucherSpec(...)` for `POST /v5/broker/award/info`.
+- Added `BybitBrokerService.IssueBrokerVoucher(...)` for `POST /v5/broker/award/distribute-award`.
+- Added `BybitBrokerService.GetIssuedBrokerVoucher(...)` for `POST /v5/broker/award/distribution-record`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
 - Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
+- Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
+- Added broker endpoint tests covering current broker routes and request payload mapping.
 
 ### Changed
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
@@ -36,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitAssetService.GetInternalTransferRecords(...)` and `GetUniversalTransferRecords(...)` to send `status` instead of `transferStatus`.
 - Updated `BybitAssetService.GetAssetAllowedDepositInfo(...)` to use the public endpoint flow instead of signed authentication.
 - Updated `BybitAssetService.GetDeliveryRecord(...)`, `GetCoinExchangeRecords(...)`, and `GetAssetUsdcSettlement(...)` to return typed response models.
+- Updated `BybitBrokerService.GetBrokerEarning(...)` to use `GET /v5/broker/earnings-info` with `begin`, `end`, and `uid` instead of the obsolete `earning-record` route and `startTime`/`endTime` fields.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitBrokerService.GetBrokerVoucherSpec(...)` for `POST /v5/broker/award/info`.
 - Added `BybitBrokerService.IssueBrokerVoucher(...)` for `POST /v5/broker/award/distribute-award`.
 - Added `BybitBrokerService.GetIssuedBrokerVoucher(...)` for `POST /v5/broker/award/distribution-record`.
+- Added easy earn methods for `GET /v5/earn/apr-history`, `GET /v5/earn/hourly-yield`, `GET /v5/earn/yield`, and `POST /v5/earn/position/modify`.
+- Added fixed-term earn methods for `GET /v5/earn/fixed-term/product`, `POST /v5/earn/fixed-term/place-order`, `GET /v5/earn/fixed-term/order`, `GET /v5/earn/fixed-term/position`, `POST /v5/earn/fixed-term/redeem`, and `POST /v5/earn/fixed-term/position/auto-invest`.
+- Added token earn methods for `GET /v5/earn/token/product`, `POST /v5/earn/token/place-order`, `GET /v5/earn/token/order`, `GET /v5/earn/token/position`, `GET /v5/earn/token/yield`, `GET /v5/earn/token/hourly-yield`, and `GET /v5/earn/token/history-apr`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
 - Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
 - Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
+- Added typed earn response models for shared earn, fixed-term earn, and BYUSDT token earn endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
+- Added earn endpoint tests covering shared earn, fixed-term, and token endpoint routing and payload mapping.
 
 ### Changed
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
@@ -47,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitAssetService.GetAssetAllowedDepositInfo(...)` to use the public endpoint flow instead of signed authentication.
 - Updated `BybitAssetService.GetDeliveryRecord(...)`, `GetCoinExchangeRecords(...)`, and `GetAssetUsdcSettlement(...)` to return typed response models.
 - Updated `BybitBrokerService.GetBrokerEarning(...)` to use `GET /v5/broker/earnings-info` with `begin`, `end`, and `uid` instead of the obsolete `earning-record` route and `startTime`/`endTime` fields.
+- Updated `BybitEarnService.GetProductInfo(...)`, `PlaceEarnOrder(...)`, `GetEarnOrderHistory(...)`, and `GetStakedPosition(...)` to return typed models instead of raw JSON strings.
+- Updated `BybitEarnService.GetEarnOrderHistory(...)` to support the documented `productId`, `startTime`, `endTime`, `limit`, and `cursor` parameters.
+- Updated `BybitEarnService` with public constructors so public earn endpoints can be used without API credentials.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitPositionService.SetPositionAutoAddMargin(...)` to make `positionIdx` optional.
 - Updated `BybitPositionService.GetMovePositionHistory(...)` and `GetClosedOptionsPositions(...)` timestamp parameters to use 64-bit values.
 - Updated `BybitPositionService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
+- Updated `BybitRateLimitService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed market response models for recent trades, open interest, insurance pool, delivery price, index price components, ADL alerts, and fee group info.
 - Added typed new crypto loan request and response models for active common, flexible, and fixed crypto loan endpoints.
 - Added typed P2P response models for active P2P ad, order, chat, account, and payment endpoints.
+- Added typed position response models for active position endpoints.
 - Added account endpoint tests covering new routes and request payload mapping.
 - Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
 - Added broker endpoint tests covering current broker routes and request payload mapping.
@@ -89,7 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitP2PService.GetAllOrders(...)` and `GetPendingOrders(...)` to send `side` as a single integer instead of an array.
 - Updated `BybitP2PService` methods to return typed P2P response models instead of raw JSON strings.
 - Updated signed REST transport to support multipart form-data requests.
+- Updated `BybitPositionService.SwitchPositionMode(...)` to send the documented `mode` field.
+- Updated `BybitPositionService.SetPositionTradingStop(...)` to send `positionIdx`, require `tpslMode`, and support `activePrice`.
+- Updated `BybitPositionService.SetPositionAutoAddMargin(...)` to make `positionIdx` optional.
+- Updated `BybitPositionService.GetMovePositionHistory(...)` and `GetClosedOptionsPositions(...)` timestamp parameters to use 64-bit values.
+- Updated `BybitPositionService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.
 - Removed the stale `GetAssetDeliveryRecords(...)` implementation that pointed to the coin exchange history route instead of the active delivery endpoint.
+- Removed the abandoned `BybitPositionService.SwitchPositionMargin(...)` method for `POST /v5/position/switch-isolated`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added token earn methods for `GET /v5/earn/token/product`, `POST /v5/earn/token/place-order`, `GET /v5/earn/token/order`, `GET /v5/earn/token/position`, `GET /v5/earn/token/yield`, `GET /v5/earn/token/hourly-yield`, and `GET /v5/earn/token/history-apr`.
 - Added `BybitLendingService.RepayInsLoan(...)` for `POST /v5/ins-loan/repay-loan`.
 - Added typed account request models for manual repay and delta mode operations.
+- Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
 - Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
 - Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added broker endpoint tests covering current broker routes and request payload mapping.
 - Added earn endpoint tests covering shared earn, fixed-term, and token endpoint routing and payload mapping.
 - Added lending endpoint tests covering current OTC routes, public access behavior, and corrected legacy lending routes.
+- Added affiliate endpoint tests covering the affiliate date-filter query mapping and typed response mapping.
 
 ### Changed
 - Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
@@ -61,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitLendingService.GetInsLoanOrders(...)` and `GetInsLoanRepayOrders(...)` to use the current OTC routes instead of the incorrect `ensure-tokens-convert` placeholder route.
 - Updated `BybitLendingService.GetInsLoanInfo(...)` and `GetInsMarginCoinInfo(...)` to use the public endpoint flow and return typed models.
 - Updated `BybitLendingService` legacy C2C methods to use typed models and corrected routes for `redeem-cancel` and `history-order`.
+- Updated `BybitAffiliateService.GetAffiliateUserList(...)` to support the documented `startDate` and `endDate` parameters.
+- Updated `BybitAffiliateService.GetAffiliateUserList(...)` and `GetAffiliateUserInfo(...)` to return typed models instead of raw JSON strings.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Spot Margin UTA methods for currency data, coin state, position tiers, max borrowable amount, repayment available amount, auto repay mode, fixed-rate borrow, fixed-rate renew, fixed-rate order/contract info, and liability endpoints.
 - Added `BybitSpreadTradingService.GetSpreadMaxOrderQty(...)` for `GET /v5/spread/max-qty`.
 - Added lightweight `BybitAlphaService` coverage for the V5 Alpha trade endpoints.
+- Added lightweight `BybitBotService` coverage for V5 spot grid, DCA, futures combo, futures grid, and futures martingale bot endpoints.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BybitNewCryptoLoanService.GetRenewOrderInfoFixed(...)` for `GET /v5/crypto-loan-fixed/renew-info`.
 - Added `BybitP2PService.ReviewSellerCancelOrderApply(...)` for `POST /v5/p2p/order/buyer/examine/sellerCancelOrderApply`.
 - Added `BybitP2PService.UploadChatFile(...)` for `POST /v5/p2p/oss/upload_file`.
+- Added `BybitRFQService.AcceptOtherQuote(...)` for `POST /v5/rfq/accept-other-quote`.
 - Added typed account request models for manual repay and delta mode operations.
 - Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
 - Added typed account response models for newly implemented account endpoints and updated account mutations.
@@ -96,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `BybitPositionService.GetMovePositionHistory(...)` and `GetClosedOptionsPositions(...)` timestamp parameters to use 64-bit values.
 - Updated `BybitPositionService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
 - Updated `BybitRateLimitService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
+- Updated RFQ quote request legs to support the documented `price` field.
 
 ### Notes
 - `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.0] - Unreleased
+
+### Added
+- Added `BybitAccountService.GetAccountInstrumentsInfo(...)` for `GET /v5/account/instruments-info`.
+- Added `BybitAccountService.ManualRepayWithoutAssetConversion(...)` for `POST /v5/account/no-convert-repay`.
+- Added `BybitAccountService.GetOptionAssetInfo()` for `GET /v5/account/option-asset-info`.
+- Added `BybitAccountService.GetPayInfo(...)` for `GET /v5/account/pay-info`.
+- Added `BybitAccountService.SetDeltaNeutralMode(...)` for `POST /v5/account/set-delta-mode`.
+- Added `BybitAccountService.GetTradeInfoForAnalysis(...)` for `GET /v5/account/trade-info-for-analysis`.
+- Added `BybitAccountService.GetTransferableAmount(...)` for `GET /v5/account/withdrawal`.
+- Added typed account request models for manual repay and delta mode operations.
+- Added typed account response models for newly implemented account endpoints and updated account mutations.
+- Added account endpoint tests covering new routes and request payload mapping.
+
+### Changed
+- Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
+- Updated `BybitAccountService.ManualRepay(...)` to support the documented `repaymentType` parameter.
+- Updated `BybitAccountService.ManualBorrow(...)`, `ManualRepay(...)`, and `SetAccountMarginMode(...)` to return typed models instead of raw JSON strings.
+
+### Notes
+- `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.

--- a/Examples/bybit.api.console/bybit.api.console.csproj
+++ b/Examples/bybit.api.console/bybit.api.console.csproj
@@ -2,15 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Your contributions are warmly welcomed and appreciated!
 **Bybit.Net.Api** constantly evolves, keeping pace with the freshest features from Bybit's API. Crafted for efficiency, the library maintains a slim profile by minimizing external dependencies. If you've broadened its horizons or ironed out bugs, we eagerly await your pull request.
 
 ## Installation
-Ensure you're using .NET 6 or newer. This SDK depends on Microsoft.Extensions.Logging 7.0.0 and Newtonsoft 13.0.3.
+Ensure you're using .NET 10 or newer. This SDK depends on Microsoft.Extensions.Logging 7.0.0 and Newtonsoft 13.0.3.
 Dotnet CLI
 ```bash
 dotnet add package bybit.net.api

--- a/Src/Common/ApiServiceImp/BybitAccountService.cs
+++ b/Src/Common/ApiServiceImp/BybitAccountService.cs
@@ -1,5 +1,6 @@
 ﻿using bybit.net.api.Models;
 using bybit.net.api.Models.Account;
+using bybit.net.api.Models.Account.Response;
 using bybit.net.api.Models.Lending;
 using bybit.net.api.Services;
 
@@ -315,13 +316,13 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="setMarginMode"></param>
         /// <returns>Margin Mode</returns>
-        public async Task<string?> SetAccountMarginMode(SetMarginMode? setMarginMode = null)
+        public async Task<GeneralResponse<SetMarginModeResult>?> SetAccountMarginMode(SetMarginMode? setMarginMode = null)
         {
             var query = new Dictionary<string, object> { };
             BybitParametersUtils.AddOptionalParameters(query,
-               ("SetMarginMode", setMarginMode?.Value)
+               ("setMarginMode", setMarginMode?.Value)
            );
-            var result = await this.SendSignedAsync<string>(ACCOUNT_MARGIN_MODE, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<SetMarginModeResult>>(ACCOUNT_MARGIN_MODE, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -441,7 +442,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Manual Borrow — POST /v5/account/borrow
         /// </summary>
-        public async Task<string?> ManualBorrow(string coin, string amount)
+        public async Task<GeneralResponse<ManualBorrowResult>?> ManualBorrow(string coin, string amount)
         {
             var body = new Dictionary<string, object>
             {
@@ -449,7 +450,7 @@ namespace bybit.net.api.ApiServiceImp
                 { "amount", amount }
             };
 
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<ManualBorrowResult>>(
                 ACCOUNT_MANUAL_BORROW,
                 HttpMethod.Post,
                 query: body);
@@ -462,18 +463,199 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Manual Repay — POST /v5/account/repay
         /// </summary>
-        public async Task<string?> ManualRepay(string? coin = null, string? amount = null)
+        public async Task<GeneralResponse<ManualRepayResult>?> ManualRepay(string? coin = null, string? amount = null, RepaymentType? repaymentType = null)
         {
             var body = new Dictionary<string, object>();
             BybitParametersUtils.AddOptionalParameters(body,
                 ("coin", coin),
-                ("amount", amount)
+                ("amount", amount),
+                ("repaymentType", repaymentType?.Value)
             );
 
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<ManualRepayResult>>(
                 ACCOUNT_MANUAL_REPAY,
                 HttpMethod.Post,
                 query: body);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Manual Repay — POST /v5/account/repay
+        /// </summary>
+        public async Task<GeneralResponse<ManualRepayResult>?> ManualRepay(ManualRepayRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return await this.ManualRepay(request.Coin, request.Amount, request.RepaymentType);
+        }
+
+        private const string ACCOUNT_NO_CONVERT_REPAY = "/v5/account/no-convert-repay";
+
+        /// <summary>
+        /// Manual Repay Without Asset Conversion — POST /v5/account/no-convert-repay
+        /// </summary>
+        public async Task<GeneralResponse<ManualRepayResult>?> ManualRepayWithoutAssetConversion(string coin, string? amount = null, RepaymentType? repaymentType = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "coin", coin }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("amount", amount),
+                ("repaymentType", repaymentType?.Value)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<ManualRepayResult>>(
+                ACCOUNT_NO_CONVERT_REPAY,
+                HttpMethod.Post,
+                query: body);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Manual Repay Without Asset Conversion — POST /v5/account/no-convert-repay
+        /// </summary>
+        public async Task<GeneralResponse<ManualRepayResult>?> ManualRepayWithoutAssetConversion(NoConvertRepayRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return await this.ManualRepayWithoutAssetConversion(request.Coin!, request.Amount, request.RepaymentType);
+        }
+
+        private const string ACCOUNT_INSTRUMENTS_INFO = "/v5/account/instruments-info";
+
+        /// <summary>
+        /// Query trading-pair instrument specifications available to the current account.
+        /// </summary>
+        public async Task<GeneralResponse<GetAccountInstrumentsInfoResult>?> GetAccountInstrumentsInfo(Category category, string? symbol = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "category", category.Value }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("symbol", symbol),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetAccountInstrumentsInfoResult>>(
+                ACCOUNT_INSTRUMENTS_INFO,
+                HttpMethod.Get,
+                query: query);
+
+            return result;
+        }
+
+        private const string ACCOUNT_OPTION_ASSET_INFO = "/v5/account/option-asset-info";
+
+        /// <summary>
+        /// Query option asset profit and loss information for each coin under the account.
+        /// </summary>
+        public async Task<GeneralResponse<GetOptionAssetInfoResult>?> GetOptionAssetInfo()
+        {
+            var result = await this.SendSignedAsync<GeneralResponse<GetOptionAssetInfoResult>>(
+                ACCOUNT_OPTION_ASSET_INFO,
+                HttpMethod.Get);
+
+            return result;
+        }
+
+        private const string ACCOUNT_PAY_INFO = "/v5/account/pay-info";
+
+        /// <summary>
+        /// Query repayment collateral information before repayment.
+        /// </summary>
+        public async Task<GeneralResponse<GetPayInfoResult>?> GetPayInfo(string? coin = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("coin", coin)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetPayInfoResult>>(
+                ACCOUNT_PAY_INFO,
+                HttpMethod.Get,
+                query: query);
+
+            return result;
+        }
+
+        private const string ACCOUNT_SET_DELTA_MODE = "/v5/account/set-delta-mode";
+
+        /// <summary>
+        /// Turn Delta Neutral mode on or off.
+        /// </summary>
+        public async Task<GeneralResponse<SetDeltaModeResult>?> SetDeltaNeutralMode(DeltaNeutralMode deltaEnable)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "deltaEnable", deltaEnable.Value }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<SetDeltaModeResult>>(
+                ACCOUNT_SET_DELTA_MODE,
+                HttpMethod.Post,
+                query: body);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Turn Delta Neutral mode on or off.
+        /// </summary>
+        public async Task<GeneralResponse<SetDeltaModeResult>?> SetDeltaNeutralMode(SetDeltaModeRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return await this.SetDeltaNeutralMode(request.DeltaEnable);
+        }
+
+        private const string ACCOUNT_TRADE_INFO_FOR_ANALYSIS = "/v5/account/trade-info-for-analysis";
+
+        /// <summary>
+        /// Query aggregated spot-trade analysis data for a symbol.
+        /// </summary>
+        public async Task<GeneralResponse<GetTradeInfoForAnalysisResult>?> GetTradeInfoForAnalysis(string symbol, long? startTime = null, long? endTime = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "symbol", symbol }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("startTime", startTime),
+                ("endTime", endTime)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetTradeInfoForAnalysisResult>>(
+                ACCOUNT_TRADE_INFO_FOR_ANALYSIS,
+                HttpMethod.Get,
+                query: query);
+
+            return result;
+        }
+
+        private const string ACCOUNT_WITHDRAWAL = "/v5/account/withdrawal";
+
+        /// <summary>
+        /// Query the available amount to transfer for coins in the Unified wallet.
+        /// </summary>
+        public async Task<GeneralResponse<GetTransferableAmountResult>?> GetTransferableAmount(string coinName)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "coinName", coinName }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetTransferableAmountResult>>(
+                ACCOUNT_WITHDRAWAL,
+                HttpMethod.Get,
+                query: query);
 
             return result;
         }

--- a/Src/Common/ApiServiceImp/BybitAffiliateService.cs
+++ b/Src/Common/ApiServiceImp/BybitAffiliateService.cs
@@ -1,10 +1,6 @@
-﻿using bybit.net.api.Models.Lending;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Affiliate;
 using bybit.net.api.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace bybit.net.api.ApiServiceImp
 {
@@ -21,23 +17,16 @@ namespace bybit.net.api.ApiServiceImp
         }
 
         private const string GET_AFFILIATE_USER_LIST = "/v5/affiliate/aff-user-list";
+        private const string GET_AFFILIATE_USER_INFO = "/v5/user/aff-customer-info";
 
-        /// <summary>
-        /// Get Affiliate User List
-        /// Requires master UID and API key with only "Affiliate" permission.
-        /// </summary>
-        /// <param name="size">[0,1000], default 0</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <param name="needDeposit">include deposit info</param>
-        /// <param name="need30">include last 30d trading info</param>
-        /// <param name="need365">include last 365d trading info</param>
-        /// <returns></returns>
-        public async Task<string?> GetAffiliateUserList(
+        public async Task<GeneralResponse<GetAffiliateUserListResult>?> GetAffiliateUserList(
             int? size = null,
             string? cursor = null,
             bool? needDeposit = null,
             bool? need30 = null,
-            bool? need365 = null)
+            bool? need365 = null,
+            string? startDate = null,
+            string? endDate = null)
         {
             var query = new Dictionary<string, object>();
 
@@ -46,27 +35,20 @@ namespace bybit.net.api.ApiServiceImp
                 ("cursor", cursor),
                 ("needDeposit", needDeposit),
                 ("need30", need30),
-                ("need365", need365)
+                ("need365", need365),
+                ("startDate", startDate),
+                ("endDate", endDate)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_AFFILIATE_USER_LIST, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetAffiliateUserListResult>>(GET_AFFILIATE_USER_LIST, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string GET_AFFILIATE_USER_INFO = "/v5/user/aff-customer-info";
-
-        /// <summary>
-        /// Get Affiliate User Info
-        /// Requires master UID and API key with only "Affiliate" permission.
-        /// </summary>
-        /// <param name="uid">Affiliate client's master UID</param>
-        /// <returns></returns>
-        public async Task<string?> GetAffiliateUserInfo(string uid)
+        public async Task<GeneralResponse<GetAffiliateUserInfoResult>?> GetAffiliateUserInfo(string uid)
         {
             var query = new Dictionary<string, object> { { "uid", uid } };
-            var result = await this.SendSignedAsync<string>(GET_AFFILIATE_USER_INFO, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetAffiliateUserInfoResult>>(GET_AFFILIATE_USER_INFO, HttpMethod.Get, query: query);
             return result;
         }
-
     }
 }

--- a/Src/Common/ApiServiceImp/BybitAlphaService.cs
+++ b/Src/Common/ApiServiceImp/BybitAlphaService.cs
@@ -1,0 +1,166 @@
+using bybit.net.api.Services;
+
+namespace bybit.net.api.ApiServiceImp
+{
+    public class BybitAlphaService : BybitApiService
+    {
+        public BybitAlphaService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitAlphaService(HttpClient httpClient, string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        private const string GET_ALPHA_ASSET_LIST = "/v5/alpha/trade/asset-list";
+        private const string GET_ALPHA_ASSET_DETAIL = "/v5/alpha/trade/asset-detail";
+        private const string GET_ALPHA_BIZ_TOKEN_LIST = "/v5/alpha/trade/biz-token-list";
+        private const string GET_ALPHA_BIZ_TOKEN_DETAILS = "/v5/alpha/trade/biz-token-details";
+        private const string GET_ALPHA_BIZ_TOKEN_PRICE_LIST = "/v5/alpha/trade/biz-token-price-list";
+        private const string GET_ALPHA_PAY_TOKEN_LIST = "/v5/alpha/trade/pay-token-list";
+        private const string GET_ALPHA_QUOTE = "/v5/alpha/trade/quote";
+        private const string PURCHASE_ALPHA_TOKEN = "/v5/alpha/trade/purchase";
+        private const string REDEEM_ALPHA_TOKEN = "/v5/alpha/trade/redeem";
+        private const string GET_ALPHA_ORDER_LIST = "/v5/alpha/trade/order-list";
+
+        public async Task<string?> GetAlphaAssetList()
+        {
+            var body = new Dictionary<string, object>();
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_ASSET_LIST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaAssetDetail(string chainCode, string tokenAddress)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "chainCode", chainCode },
+                { "tokenAddress", tokenAddress }
+            };
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_ASSET_DETAIL, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaBizTokenList(int? tokenTag = null)
+        {
+            var body = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("tokenTag", tokenTag)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_BIZ_TOKEN_LIST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaBizTokenDetails(string chainCode, string tokenAddress)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "chainCode", chainCode },
+                { "tokenAddress", tokenAddress }
+            };
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_BIZ_TOKEN_DETAILS, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaBizTokenPriceList(IEnumerable<object> tokenAddressInfo)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "tokenAddressInfo", tokenAddressInfo.ToArray() }
+            };
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_BIZ_TOKEN_PRICE_LIST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaPayTokenList(string chainCode, string tokenAddress)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "chainCode", chainCode },
+                { "tokenAddress", tokenAddress }
+            };
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_PAY_TOKEN_LIST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaQuote(int tradeType, string fromTokenCode, string fromTokenAmount, string toTokenCode, int? quoteMode = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "tradeType", tradeType },
+                { "fromTokenCode", fromTokenCode },
+                { "fromTokenAmount", fromTokenAmount },
+                { "toTokenCode", toTokenCode }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("quoteMode", quoteMode)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_QUOTE, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> PurchaseAlphaToken(string fromTokenCode, string fromTokenAmount, string toTokenCode, string slippage, string quoteData, string gas, int quoteMode, string correctingCode, string? tenant = null)
+        {
+            var body = BuildAlphaTradeBody(fromTokenCode, fromTokenAmount, toTokenCode, slippage, quoteData, gas, quoteMode, correctingCode, tenant);
+            var result = await this.SendSignedAsync<string>(PURCHASE_ALPHA_TOKEN, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> RedeemAlphaToken(string fromTokenCode, string fromTokenAmount, string toTokenCode, string slippage, string quoteData, string gas, int quoteMode, string correctingCode, string? tenant = null)
+        {
+            var body = BuildAlphaTradeBody(fromTokenCode, fromTokenAmount, toTokenCode, slippage, quoteData, gas, quoteMode, correctingCode, tenant);
+            var result = await this.SendSignedAsync<string>(REDEEM_ALPHA_TOKEN, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<string?> GetAlphaOrderList(int limit, int pageIndex, int? tradeType = null, string? tokenCode = null, IEnumerable<int>? orderStatus = null, int? days = null, string? direction = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "limit", limit },
+                { "pageIndex", pageIndex }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("tradeType", tradeType),
+                ("tokenCode", tokenCode),
+                ("orderStatus", orderStatus?.ToArray()),
+                ("days", days),
+                ("direction", direction)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_ALPHA_ORDER_LIST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        private static Dictionary<string, object> BuildAlphaTradeBody(string fromTokenCode, string fromTokenAmount, string toTokenCode, string slippage, string quoteData, string gas, int quoteMode, string correctingCode, string? tenant)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "fromTokenCode", fromTokenCode },
+                { "fromTokenAmount", fromTokenAmount },
+                { "toTokenCode", toTokenCode },
+                { "slippage", slippage },
+                { "quoteData", quoteData },
+                { "gas", gas },
+                { "quoteMode", quoteMode },
+                { "correctingCode", correctingCode }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("tenant", tenant)
+            );
+
+            return body;
+        }
+    }
+}

--- a/Src/Common/ApiServiceImp/BybitAssetService.cs
+++ b/Src/Common/ApiServiceImp/BybitAssetService.cs
@@ -8,6 +8,16 @@ namespace bybit.net.api.ApiServiceImp
 {
     public class BybitAssetService : BybitApiService
     {
+        public BybitAssetService(string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitAssetService(HttpClient httpClient, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
         public BybitAssetService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
         : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
         {
@@ -32,7 +42,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit">[1,50], default 20</param>
         /// <param name="cursor">pagination cursor</param>
         /// <returns></returns>
-        public async Task<string?> GetDeliveryRecord(
+        public async Task<GeneralResponse<GetDeliveryRecordResult>?> GetDeliveryRecord(
             string category,
             string? symbol = null,
             long? startTime = null,
@@ -52,7 +62,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("cursor", cursor)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_DELIVERY_RECORD, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetDeliveryRecordResult>>(GET_DELIVERY_RECORD, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -68,7 +78,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Coin Exchange Records</returns>
-        public async Task<string?> GetCoinExchangeRecords(string? fromCoin = null, string? toCoin = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetCoinExchangeRecordsResult>?> GetCoinExchangeRecords(string? fromCoin = null, string? toCoin = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
 
@@ -78,32 +88,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(COIN_EXCHANGE_RECORDS, HttpMethod.Get, query: query);
-            return result;
-        }
-
-        private const string ASSET_DELIVERY_RECORDS = "/v5/asset/exchange/order-record";
-        /// <summary>
-        /// Query delivery records of USDC futures and Options, sorted by deliveryTime in descending order
-        /// Unified account covers: USDC futures / Option
-        /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="expDate"></param>
-        /// <param name="limit"></param>
-        /// <param name="cursor"></param>
-        /// <returns>Delivery Records</returns>
-        public async Task<string?> GetAssetDeliveryRecords(Category category, string? symbol = null, string? expDate = null, int? limit = null, string? cursor = null)
-        {
-            var query = new Dictionary<string, object> { { "category", category.Value } };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("symbol", symbol),
-                ("expDate", expDate),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-            var result = await this.SendSignedAsync<string>(ASSET_DELIVERY_RECORDS, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetCoinExchangeRecordsResult>>(COIN_EXCHANGE_RECORDS, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -117,16 +102,18 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Usdc Settlements</returns>
-        public async Task<string?> GetAssetUsdcSettlement(Category category, string? symbol = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetUsdcSettlementResult>?> GetAssetUsdcSettlement(Category category, string? symbol = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("symbol", symbol),
+                ("startTime", startTime),
+                ("endTime", endTime),
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(USDC_SETTLEMENT, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetUsdcSettlementResult>>(USDC_SETTLEMENT, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -211,10 +198,10 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="accountType"></param>
         /// <param name="toAccountType"></param>
         /// <returns>List of coin</returns>
-        public async Task<string?> GetTransferableCoin(AccountType accountType, AccountType toAccountType)
+        public async Task<GeneralResponse<GetTransferableCoinResult>?> GetTransferableCoin(AccountType accountType, AccountType toAccountType)
         {
-            var query = new Dictionary<string, object> { { "accountType", accountType.Value }, { "toAccountType", toAccountType.Value } };
-            var result = await this.SendSignedAsync<string>(TRANSABLE_COIN, HttpMethod.Get, query: query);
+            var query = new Dictionary<string, object> { { "fromAccountType", accountType.Value }, { "toAccountType", toAccountType.Value } };
+            var result = await this.SendSignedAsync<GeneralResponse<GetTransferableCoinResult>>(TRANSABLE_COIN, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -229,12 +216,12 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="coin"></param>
         /// <param name="amount"></param>
         /// <returns>transferId</returns>
-        public async Task<string?> CreateInternalTransfer(AccountType accountType, AccountType toAccountType, string coin, string amount, string? transferId = null)
+        public async Task<GeneralResponse<CreateTransferResult>?> CreateInternalTransfer(AccountType accountType, AccountType toAccountType, string coin, string amount, string? transferId = null)
         {
-            var query = new Dictionary<string, object> { { "accountType", accountType.Value }, { "toAccountType", toAccountType.Value }, { "coin", coin }, { "amount", amount } };
+            var query = new Dictionary<string, object> { { "fromAccountType", accountType.Value }, { "toAccountType", toAccountType.Value }, { "coin", coin }, { "amount", amount } };
             if (string.IsNullOrEmpty(transferId)) transferId = BybitParametersUtils.GenerateTransferId();
             query.Add("transferId", transferId);
-            var result = await this.SendSignedAsync<string>(INTERNAL_TRANSFER, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<CreateTransferResult>>(INTERNAL_TRANSFER, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -254,12 +241,12 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="coin"></param>
         /// <param name="amount"></param>
         /// <returns>transferId</returns>
-        public async Task<string?> CreateUniversalTransfer(AccountType accountType, AccountType toAccountType, string fromMemberId, string toMemberId, string coin, string amount, string? transferId = null)
+        public async Task<GeneralResponse<CreateTransferResult>?> CreateUniversalTransfer(AccountType accountType, AccountType toAccountType, string fromMemberId, string toMemberId, string coin, string amount, string? transferId = null)
         {
-            var query = new Dictionary<string, object> { { "accountType", accountType.Value }, { "toAccountType", toAccountType.Value }, { "fromMemberId", fromMemberId }, { "toMemberId", toMemberId }, { "coin", coin }, { "amount", amount } };
+            var query = new Dictionary<string, object> { { "fromAccountType", accountType.Value }, { "toAccountType", toAccountType.Value }, { "fromMemberId", fromMemberId }, { "toMemberId", toMemberId }, { "coin", coin }, { "amount", amount } };
             if (string.IsNullOrEmpty(transferId)) transferId = BybitParametersUtils.GenerateTransferId();
             query.Add("transferId", transferId);
-            var result = await this.SendSignedAsync<string>(UNIVERSAL_TRANSFER, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<CreateTransferResult>>(UNIVERSAL_TRANSFER, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -275,20 +262,20 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Internal Transfers</returns>
-        public async Task<string?> GetInternalTransferRecords(string? transferId = null, string? coin = null, TransferStatus? transferStatus = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetTransferRecordsResult>?> GetInternalTransferRecords(string? transferId = null, string? coin = null, TransferStatus? transferStatus = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("transferId", transferId),
                 ("coin", coin),
-                ("transferStatus", transferStatus?.Value),
+                ("status", transferStatus?.Value),
                 ("startTime", startTime),
                 ("endTime", endTime),
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(INTERNAL_TRANSFER_RECORDS, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetTransferRecordsResult>>(INTERNAL_TRANSFER_RECORDS, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -307,20 +294,20 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Universal Transfers</returns>
-        public async Task<string?> GetUniversalTransferRecords(string? transferId = null, string? coin = null, TransferStatus? transferStatus = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetTransferRecordsResult>?> GetUniversalTransferRecords(string? transferId = null, string? coin = null, TransferStatus? transferStatus = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("transferId", transferId),
                 ("coin", coin),
-                ("transferStatus", transferStatus?.Value),
+                ("status", transferStatus?.Value),
                 ("startTime", startTime),
                 ("endTime", endTime),
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(UNIVERSAL_TRANSFER_RECORDS, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetTransferRecordsResult>>(UNIVERSAL_TRANSFER_RECORDS, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -347,7 +334,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Deposited Coin Info</returns>
-        public async Task<string?> GetAssetAllowedDepositInfo(string? chain = null, string? coin = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetAllowedDepositCoinInfoResult>?> GetAssetAllowedDepositInfo(string? chain = null, string? coin = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { };
 
@@ -357,7 +344,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(ALLOW_DEPOSIT_COINS, HttpMethod.Get, query: query);
+            var result = await this.SendPublicAsync<GeneralResponse<GetAllowedDepositCoinInfoResult>>(ALLOW_DEPOSIT_COINS, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -760,6 +747,236 @@ namespace bybit.net.api.ApiServiceImp
 
             var result = await this.SendSignedAsync<string>(GET_CONVERT_COIN_LIST, HttpMethod.Get, query: query);
             return result;
+        }
+
+        private const string GET_FUNDING_HISTORY = "/v5/asset/fundinghistory";
+
+        public async Task<GeneralResponse<GetFundingHistoryResult>?> GetFundingAccountTransactionHistory(string? createTimeFrom = null, string? createTimeTo = null, string? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("createTimeFrom", createTimeFrom),
+                ("createTimeTo", createTimeTo),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetFundingHistoryResult>>(GET_FUNDING_HISTORY, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_PORTFOLIO_MARGIN_INFO = "/v5/asset/portfolio-margin";
+
+        public async Task<GeneralResponse<GetPortfolioMarginInfoResult>?> GetPortfolioMarginInfo(string? baseCoin = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("baseCoin", baseCoin)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetPortfolioMarginInfoResult>>(GET_PORTFOLIO_MARGIN_INFO, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_TOTAL_MEMBERS_ASSETS = "/v5/asset/total-members-assets";
+
+        public async Task<GeneralResponse<GetTotalMembersAssetsResult>?> GetTotalMembersAssets(string? coin = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("coin", coin)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetTotalMembersAssetsResult>>(GET_TOTAL_MEMBERS_ASSETS, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_ASSET_OVERVIEW = "/v5/asset/asset-overview";
+
+        public async Task<GeneralResponse<GetAssetOverviewResult>?> GetAssetOverview(string? memberId = null, string? valuationCurrency = null, string? accountType = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("memberId", memberId),
+                ("valuationCurrency", valuationCurrency),
+                ("accountType", accountType)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetAssetOverviewResult>>(GET_ASSET_OVERVIEW, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_WITHDRAWAL_ADDRESS_LIST = "/v5/asset/withdraw/query-address";
+
+        public async Task<GeneralResponse<GetWithdrawalAddressListResult>?> GetWithdrawalAddressList(string? coin = null, string? chain = null, int? addressType = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("coin", coin),
+                ("chain", chain),
+                ("addressType", addressType),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetWithdrawalAddressListResult>>(GET_WITHDRAWAL_ADDRESS_LIST, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_SMALL_BALANCE_COINS = "/v5/asset/covert/small-balance-list";
+
+        public async Task<GeneralResponse<GetSmallBalanceCoinsResult>?> GetSmallBalanceCoins(string accountType, string? fromCoin = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "accountType", accountType }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("fromCoin", fromCoin)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetSmallBalanceCoinsResult>>(GET_SMALL_BALANCE_COINS, HttpMethod.Get, query: query);
+        }
+
+        private const string REQUEST_SMALL_BALANCE_QUOTE = "/v5/asset/covert/get-quote";
+
+        public async Task<GeneralResponse<RequestSmallBalanceQuoteResult>?> RequestSmallBalanceQuote(string accountType, List<string> fromCoinList, string toCoin)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "accountType", accountType },
+                { "fromCoinList", fromCoinList },
+                { "toCoin", toCoin }
+            };
+
+            return await this.SendSignedAsync<GeneralResponse<RequestSmallBalanceQuoteResult>>(REQUEST_SMALL_BALANCE_QUOTE, HttpMethod.Post, query: body);
+        }
+
+        private const string CONFIRM_SMALL_BALANCE_QUOTE = "/v5/asset/covert/small-balance-execute";
+
+        public async Task<GeneralResponse<ConfirmSmallBalanceQuoteResult>?> ConfirmSmallBalanceQuote(string quoteId)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "quoteId", quoteId }
+            };
+
+            return await this.SendSignedAsync<GeneralResponse<ConfirmSmallBalanceQuoteResult>>(CONFIRM_SMALL_BALANCE_QUOTE, HttpMethod.Post, query: body);
+        }
+
+        private const string GET_SMALL_BALANCE_HISTORY = "/v5/asset/covert/small-balance-history";
+
+        public async Task<GeneralResponse<GetSmallBalanceExchangeHistoryResult>?> GetSmallBalanceExchangeHistory(string? accountType = null, string? quoteId = null, string? startTime = null, string? endTime = null, string? cursor = null, string? size = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("accountType", accountType),
+                ("quoteId", quoteId),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("cursor", cursor),
+                ("size", size)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetSmallBalanceExchangeHistoryResult>>(GET_SMALL_BALANCE_HISTORY, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_FIAT_BALANCE = "/v5/fiat/balance-query";
+
+        public async Task<GeneralResponse<List<GetFiatBalanceResult>>?> GetFiatBalance(string? currency = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<List<GetFiatBalanceResult>>>(GET_FIAT_BALANCE, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_FIAT_TRADING_PAIR_LIST = "/v5/fiat/query-coin-list";
+
+        public async Task<GeneralResponse<GetFiatTradingPairListResult>?> GetFiatTradingPairList(string? side = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("side", side)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetFiatTradingPairListResult>>(GET_FIAT_TRADING_PAIR_LIST, HttpMethod.Get, query: query);
+        }
+
+        private const string REQUEST_FIAT_QUOTE = "/v5/fiat/quote-apply";
+
+        public async Task<GeneralResponse<RequestFiatQuoteResult>?> RequestFiatQuote(string fromCoin, string fromCoinType, string toCoin, string toCoinType, string requestAmount, string? requestCoinType = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "fromCoin", fromCoin },
+                { "fromCoinType", fromCoinType },
+                { "toCoin", toCoin },
+                { "toCoinType", toCoinType },
+                { "requestAmount", requestAmount }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("requestCoinType", requestCoinType)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<RequestFiatQuoteResult>>(REQUEST_FIAT_QUOTE, HttpMethod.Post, query: body);
+        }
+
+        private const string CONFIRM_FIAT_QUOTE = "/v5/fiat/trade-execute";
+
+        public async Task<GeneralResponse<ConfirmFiatQuoteResult>?> ConfirmFiatQuote(string quoteTxId, string subUserId, string? webhookUrl = null, string? merchantRequestId = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "quoteTxId", quoteTxId },
+                { "subUserId", subUserId }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("webhookUrl", webhookUrl),
+                ("MerchantRequestId", merchantRequestId)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<ConfirmFiatQuoteResult>>(CONFIRM_FIAT_QUOTE, HttpMethod.Post, query: body);
+        }
+
+        private const string GET_FIAT_CONVERT_STATUS = "/v5/fiat/trade-query";
+
+        public async Task<GeneralResponse<GetFiatConvertStatusResult>?> GetFiatConvertStatus(string? tradeNo = null, string? merchantRequestId = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("tradeNo", tradeNo),
+                ("merchantRequestId", merchantRequestId)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<GetFiatConvertStatusResult>>(GET_FIAT_CONVERT_STATUS, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_FIAT_CONVERT_HISTORY = "/v5/fiat/query-trade-history";
+
+        public async Task<GeneralResponse<List<GetFiatConvertStatusResult>>?> GetFiatConvertHistory(int? index = null, int? limit = null, string? startTime = null, string? endTime = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("index", index),
+                ("limit", limit),
+                ("startTime", startTime),
+                ("endTime", endTime)
+            );
+
+            return await this.SendSignedAsync<GeneralResponse<List<GetFiatConvertStatusResult>>>(GET_FIAT_CONVERT_HISTORY, HttpMethod.Get, query: query);
+        }
+
+        private const string GET_FIAT_REFERENCE_PRICE = "/v5/fiat/reference-price";
+
+        public async Task<GeneralResponse<GetFiatReferencePriceResult>?> GetFiatReferencePrice(string symbol)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "symbol", symbol }
+            };
+
+            return await this.SendSignedAsync<GeneralResponse<GetFiatReferencePriceResult>>(GET_FIAT_REFERENCE_PRICE, HttpMethod.Get, query: query);
         }
 
 

--- a/Src/Common/ApiServiceImp/BybitBotService.cs
+++ b/Src/Common/ApiServiceImp/BybitBotService.cs
@@ -1,0 +1,148 @@
+using bybit.net.api.Services;
+
+namespace bybit.net.api.ApiServiceImp
+{
+    public class BybitBotService : BybitApiService
+    {
+        public BybitBotService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitBotService(HttpClient httpClient, string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        private const string VALIDATE_SPOT_GRID_INPUT = "/v5/grid/validate-input";
+        private const string CREATE_SPOT_GRID_BOT = "/v5/grid/create-grid";
+        private const string CLOSE_SPOT_GRID_BOT = "/v5/grid/close-grid";
+        private const string GET_SPOT_GRID_BOT_DETAIL = "/v5/grid/query-grid-detail";
+
+        private const string CREATE_DCA_BOT = "/v5/dca/create-bot";
+        private const string CLOSE_DCA_BOT = "/v5/dca/close-bot";
+
+        private const string CREATE_FUTURES_COMBO_BOT = "/v5/fcombobot/create";
+        private const string GET_FUTURES_COMBO_BOT_LIMIT = "/v5/fcombobot/getlimit";
+        private const string CLOSE_FUTURES_COMBO_BOT = "/v5/fcombobot/close";
+        private const string GET_FUTURES_COMBO_BOT_DETAIL = "/v5/fcombobot/detail";
+
+        private const string VALIDATE_FUTURES_GRID_INPUT = "/v5/fgridbot/validate";
+        private const string CREATE_FUTURES_GRID_BOT = "/v5/fgridbot/create";
+        private const string CLOSE_FUTURES_GRID_BOT = "/v5/fgridbot/close";
+        private const string GET_FUTURES_GRID_BOT_DETAIL = "/v5/fgridbot/detail";
+
+        private const string CREATE_FUTURES_MARTINGALE_BOT = "/v5/fmartingalebot/create";
+        private const string GET_FUTURES_MARTINGALE_BOT_LIMIT = "/v5/fmartingalebot/getlimit";
+        private const string CLOSE_FUTURES_MARTINGALE_BOT = "/v5/fmartingalebot/close";
+        private const string GET_FUTURES_MARTINGALE_BOT_DETAIL = "/v5/fmartingalebot/detail";
+
+        public async Task<string?> ValidateSpotGridInput(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(VALIDATE_SPOT_GRID_INPUT, parameters);
+        }
+
+        public async Task<string?> CreateSpotGridBot(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(CREATE_SPOT_GRID_BOT, parameters);
+        }
+
+        public async Task<string?> CloseSpotGridBot(string gridId, string closeMode)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "grid_id", gridId },
+                { "close_mode", closeMode }
+            };
+
+            return await SendBotRequest(CLOSE_SPOT_GRID_BOT, body);
+        }
+
+        public async Task<string?> GetSpotGridBotDetail(string gridId)
+        {
+            return await SendBotRequest(GET_SPOT_GRID_BOT_DETAIL, new Dictionary<string, object> { { "grid_id", gridId } });
+        }
+
+        public async Task<string?> CreateDcaBot(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(CREATE_DCA_BOT, new Dictionary<string, object> { { "parameters", parameters } });
+        }
+
+        public async Task<string?> CloseDcaBot(string botId, string closeMode)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "bot_id", botId },
+                { "close_mode", closeMode }
+            };
+
+            return await SendBotRequest(CLOSE_DCA_BOT, body);
+        }
+
+        public async Task<string?> CreateFuturesComboBot(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(CREATE_FUTURES_COMBO_BOT, parameters);
+        }
+
+        public async Task<string?> GetFuturesComboBotLimit(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(GET_FUTURES_COMBO_BOT_LIMIT, parameters);
+        }
+
+        public async Task<string?> CloseFuturesComboBot(string botId)
+        {
+            return await SendBotRequest(CLOSE_FUTURES_COMBO_BOT, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        public async Task<string?> GetFuturesComboBotDetail(string botId)
+        {
+            return await SendBotRequest(GET_FUTURES_COMBO_BOT_DETAIL, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        public async Task<string?> ValidateFuturesGridInput(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(VALIDATE_FUTURES_GRID_INPUT, parameters);
+        }
+
+        public async Task<string?> CreateFuturesGridBot(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(CREATE_FUTURES_GRID_BOT, parameters);
+        }
+
+        public async Task<string?> CloseFuturesGridBot(string botId)
+        {
+            return await SendBotRequest(CLOSE_FUTURES_GRID_BOT, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        public async Task<string?> GetFuturesGridBotDetail(string botId)
+        {
+            return await SendBotRequest(GET_FUTURES_GRID_BOT_DETAIL, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        public async Task<string?> CreateFuturesMartingaleBot(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(CREATE_FUTURES_MARTINGALE_BOT, parameters);
+        }
+
+        public async Task<string?> GetFuturesMartingaleBotLimit(Dictionary<string, object> parameters)
+        {
+            return await SendBotRequest(GET_FUTURES_MARTINGALE_BOT_LIMIT, parameters);
+        }
+
+        public async Task<string?> CloseFuturesMartingaleBot(string botId)
+        {
+            return await SendBotRequest(CLOSE_FUTURES_MARTINGALE_BOT, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        public async Task<string?> GetFuturesMartingaleBotDetail(string botId)
+        {
+            return await SendBotRequest(GET_FUTURES_MARTINGALE_BOT_DETAIL, new Dictionary<string, object> { { "bot_id", botId } });
+        }
+
+        private async Task<string?> SendBotRequest(string endpoint, Dictionary<string, object> body)
+        {
+            var result = await this.SendSignedAsync<string>(endpoint, HttpMethod.Post, query: body);
+            return result;
+        }
+    }
+}

--- a/Src/Common/ApiServiceImp/BybitBrokerService.cs
+++ b/Src/Common/ApiServiceImp/BybitBrokerService.cs
@@ -1,4 +1,6 @@
-﻿using bybit.net.api.Models.Lending;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Broker;
+using bybit.net.api.Models.Lending;
 using bybit.net.api.Services;
 
 namespace bybit.net.api.ApiServiceImp
@@ -15,20 +17,139 @@ namespace bybit.net.api.ApiServiceImp
         {
         }
 
-        private const string BROKER_EARNING_DATA = "/v5/broker/earning-record";
-       
-        public async Task<string?> GetBrokerEarning(BizType? bizType = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        private const string BROKER_EARNING_DATA = "/v5/broker/earnings-info";
+        private const string BROKER_ACCOUNT_INFO = "/v5/broker/account-info";
+        private const string BROKER_SUB_MEMBER_DEPOSIT_RECORD = "/v5/broker/asset/query-sub-member-deposit-record";
+        private const string BROKER_RATE_LIMIT_ALL = "/v5/broker/apilimit/query-all";
+        private const string BROKER_RATE_LIMIT_CAP = "/v5/broker/apilimit/query-cap";
+        private const string BROKER_RATE_LIMIT_SET = "/v5/broker/apilimit/set";
+        private const string BROKER_VOUCHER_INFO = "/v5/broker/award/info";
+        private const string BROKER_ISSUE_VOUCHER = "/v5/broker/award/distribute-award";
+        private const string BROKER_ISSUED_VOUCHER = "/v5/broker/award/distribution-record";
+
+        public async Task<GeneralResponse<GetBrokerEarningResult>?> GetBrokerEarning(BizType? bizType = null, string? begin = null, string? end = null, string? uid = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("bizType", bizType?.Value),
+                ("begin", begin),
+                ("end", end),
+                ("uid", uid),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerEarningResult>>(BROKER_EARNING_DATA, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetBrokerAccountInfoResult>?> GetBrokerAccountInfo()
+        {
+            var query = new Dictionary<string, object>();
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerAccountInfoResult>>(BROKER_ACCOUNT_INFO, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetBrokerSubMemberDepositRecordsResult>?> GetBrokerSubMemberDepositRecords(
+            string? id = null,
+            string? txId = null,
+            string? subMemberId = null,
+            string? coin = null,
+            long? startTime = null,
+            long? endTime = null,
+            int? limit = null,
+            string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("id", id),
+                ("txID", txId),
+                ("subMemberId", subMemberId),
+                ("coin", coin),
                 ("startTime", startTime),
                 ("endTime", endTime),
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(BROKER_EARNING_DATA, HttpMethod.Get, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerSubMemberDepositRecordsResult>>(BROKER_SUB_MEMBER_DEPOSIT_RECORD, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetBrokerRateLimitAllResult>?> GetBrokerAllRateLimits(int? limit = null, string? cursor = null, string? uids = null)
+        {
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("limit", limit),
+                ("cursor", cursor),
+                ("uids", uids)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerRateLimitAllResult>>(BROKER_RATE_LIMIT_ALL, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetBrokerRateLimitCapResult>?> GetBrokerRateLimitCap()
+        {
+            var query = new Dictionary<string, object>();
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerRateLimitCapResult>>(BROKER_RATE_LIMIT_CAP, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<SetBrokerRateLimitResult>?> SetBrokerRateLimit(List<BrokerRateLimitRequestItem> list)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "list", list }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<SetBrokerRateLimitResult>>(BROKER_RATE_LIMIT_SET, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetBrokerVoucherSpecResult>?> GetBrokerVoucherSpec(string id)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "id", id }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetBrokerVoucherSpecResult>>(BROKER_VOUCHER_INFO, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<IssueBrokerVoucherResult>?> IssueBrokerVoucher(string accountId, string awardId, string specCode, string amount, string brokerId)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "accountId", accountId },
+                { "awardId", awardId },
+                { "specCode", specCode },
+                { "amount", amount },
+                { "brokerId", brokerId }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<IssueBrokerVoucherResult>>(BROKER_ISSUE_VOUCHER, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetIssuedBrokerVoucherResult>?> GetIssuedBrokerVoucher(string accountId, string awardId, string specCode, bool? withUsedAmount = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "accountId", accountId },
+                { "awardId", awardId },
+                { "specCode", specCode }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("withUsedAmount", withUsedAmount)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetIssuedBrokerVoucherResult>>(BROKER_ISSUED_VOUCHER, HttpMethod.Post, query: body);
             return result;
         }
     }

--- a/Src/Common/ApiServiceImp/BybitEarnService.cs
+++ b/Src/Common/ApiServiceImp/BybitEarnService.cs
@@ -1,14 +1,21 @@
-﻿using bybit.net.api.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Earn;
+using bybit.net.api.Services;
 
 namespace bybit.net.api.ApiServiceImp
 {
     public class BybitEarnService : BybitApiService
     {
+        public BybitEarnService(string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitEarnService(HttpClient httpClient, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
         public BybitEarnService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
         : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
         {
@@ -20,42 +27,39 @@ namespace bybit.net.api.ApiServiceImp
         }
 
         private const string GET_PRODUCT_INFO = "/v5/earn/product";
+        private const string PLACE_EARN_ORDER = "/v5/earn/place-order";
+        private const string GET_EARN_ORDER_HISTORY = "/v5/earn/order";
+        private const string GET_STAKED_POSITION = "/v5/earn/position";
+        private const string GET_EARN_APR_HISTORY = "/v5/earn/apr-history";
+        private const string GET_EARN_HOURLY_YIELD = "/v5/earn/hourly-yield";
+        private const string GET_EARN_YIELD_HISTORY = "/v5/earn/yield";
+        private const string MODIFY_EARN_POSITION = "/v5/earn/position/modify";
 
-        /// <summary>
-        /// Get Product Info
-        /// Public. Returns Earn product specs for FlexibleSaving or OnChain.
-        /// </summary>
-        /// <param name="category">FlexibleSaving or OnChain</param>
-        /// <param name="coin">Optional coin</param>
-        /// <returns></returns>
-        public async Task<string?> GetProductInfo(string category, string? coin = null)
+        private const string GET_FIXED_TERM_PRODUCT = "/v5/earn/fixed-term/product";
+        private const string PLACE_FIXED_TERM_ORDER = "/v5/earn/fixed-term/place-order";
+        private const string GET_FIXED_TERM_ORDER = "/v5/earn/fixed-term/order";
+        private const string GET_FIXED_TERM_POSITION = "/v5/earn/fixed-term/position";
+        private const string REDEEM_FIXED_TERM = "/v5/earn/fixed-term/redeem";
+        private const string SET_FIXED_TERM_AUTO_INVEST = "/v5/earn/fixed-term/position/auto-invest";
+
+        private const string GET_TOKEN_PRODUCT = "/v5/earn/token/product";
+        private const string PLACE_TOKEN_ORDER = "/v5/earn/token/place-order";
+        private const string GET_TOKEN_ORDER = "/v5/earn/token/order";
+        private const string GET_TOKEN_POSITION = "/v5/earn/token/position";
+        private const string GET_TOKEN_YIELD = "/v5/earn/token/yield";
+        private const string GET_TOKEN_HOURLY_YIELD = "/v5/earn/token/hourly-yield";
+        private const string GET_TOKEN_HISTORY_APR = "/v5/earn/token/history-apr";
+
+        public async Task<GeneralResponse<GetProductInfoResult>?> GetProductInfo(string category, string? coin = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
             BybitParametersUtils.AddOptionalParameters(query, ("coin", coin));
 
-            var result = await this.SendPublicAsync<string>(GET_PRODUCT_INFO, HttpMethod.Get, query: query);
+            var result = await this.SendPublicAsync<GeneralResponse<GetProductInfoResult>>(GET_PRODUCT_INFO, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string PLACE_EARN_ORDER = "/v5/earn/place-order";
-
-        /// <summary>
-        /// Stake / Redeem
-        /// Place Earn order for FlexibleSaving or OnChain. API key needs "Earn" permission.
-        /// </summary>
-        /// <param name="category">FlexibleSaving or OnChain</param>
-        /// <param name="orderType">Stake or Redeem</param>
-        /// <param name="accountType">FUND or UNIFIED (OnChain supports FUND only)</param>
-        /// <param name="amount">Amount; must meet product precision/limits</param>
-        /// <param name="coin">Coin name</param>
-        /// <param name="productId">Product ID</param>
-        /// <param name="orderLinkId">Custom ID, up to 36 chars</param>
-        /// <param name="redeemPositionId">Required for OnChain non-LST redeem</param>
-        /// <param name="toAccountType">
-        /// FUND or UNIFIED. OnChain LST: FUND/UNIFIED (custodial subaccount UNIFIED only). OnChain non-LST: FUND only.
-        /// </param>
-        /// <returns></returns>
-        public async Task<string?> PlaceEarnOrder(
+        public async Task<GeneralResponse<PlaceEarnOrderResult>?> PlaceEarnOrder(
             string category,
             string orderType,
             string accountType,
@@ -82,47 +86,37 @@ namespace bybit.net.api.ApiServiceImp
                 ("toAccountType", toAccountType)
             );
 
-            var result = await this.SendSignedAsync<string>(PLACE_EARN_ORDER, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<GeneralResponse<PlaceEarnOrderResult>>(PLACE_EARN_ORDER, HttpMethod.Post, query: body);
             return result;
         }
 
-        private const string GET_EARN_ORDER_HISTORY = "/v5/earn/order";
-
-        /// <summary>
-        /// Get Stake/Redeem Order History
-        /// Earn permission required. For FlexibleSaving or OnChain.
-        /// </summary>
-        /// <param name="category">FlexibleSaving or OnChain</param>
-        /// <param name="orderId">Order ID (required if orderLinkId is null)</param>
-        /// <param name="orderLinkId">
-        /// Order link ID (required if orderId is null). If reused, returns the latest.
-        /// </param>
-        /// <returns></returns>
-        public async Task<string?> GetEarnOrderHistory(string category, string? orderId = null, string? orderLinkId = null)
+        public async Task<GeneralResponse<GetStakeRedeemOrderHistoryResult>?> GetEarnOrderHistory(
+            string category,
+            string? orderId = null,
+            string? orderLinkId = null,
+            string? productId = null,
+            long? startTime = null,
+            long? endTime = null,
+            int? limit = null,
+            string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("orderId", orderId),
-                ("orderLinkId", orderLinkId)
+                ("orderLinkId", orderLinkId),
+                ("productId", productId),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("limit", limit),
+                ("cursor", cursor)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_EARN_ORDER_HISTORY, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetStakeRedeemOrderHistoryResult>>(GET_EARN_ORDER_HISTORY, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string GET_STAKED_POSITION = "/v5/earn/position";
-
-        /// <summary>
-        /// Get Staked Position
-        /// Earn permission required. FlexibleSaving returns active and fully redeemed positions.
-        /// OnChain returns active positions only.
-        /// </summary>
-        /// <param name="category">FlexibleSaving or OnChain</param>
-        /// <param name="productId">Optional product ID</param>
-        /// <param name="coin">Optional coin</param>
-        /// <returns></returns>
-        public async Task<string?> GetStakedPosition(string category, string? productId = null, string? coin = null)
+        public async Task<GeneralResponse<GetStakedPositionResult>?> GetStakedPosition(string category, string? productId = null, string? coin = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
@@ -131,7 +125,248 @@ namespace bybit.net.api.ApiServiceImp
                 ("coin", coin)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_STAKED_POSITION, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetStakedPositionResult>>(GET_STAKED_POSITION, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetEarnAprHistoryResult>?> GetEarnAprHistory(string category, string productId, long? startTime = null, long? endTime = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "category", category },
+                { "productId", productId }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("startTime", startTime),
+                ("endTime", endTime)
+            );
+
+            var result = await this.SendPublicAsync<GeneralResponse<GetEarnAprHistoryResult>>(GET_EARN_APR_HISTORY, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetEarnHourlyYieldResult>?> GetEarnHourlyYield(string category, string? productId = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object> { { "category", category } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("productId", productId),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetEarnHourlyYieldResult>>(GET_EARN_HOURLY_YIELD, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetEarnYieldHistoryResult>?> GetEarnYieldHistory(string category, string? productId = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object> { { "category", category } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("productId", productId),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetEarnYieldHistoryResult>>(GET_EARN_YIELD_HISTORY, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<ModifyEarnPositionResult>?> ModifyEarnPosition(string category, int productId, int positionId, int autoReinvest)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "category", category },
+                { "productId", productId },
+                { "positionId", positionId },
+                { "autoReinvest", autoReinvest }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<ModifyEarnPositionResult>>(MODIFY_EARN_POSITION, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetFixedTermProductInfoResult>?> GetFixedTermProductInfo(string? coin = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query, ("coin", coin));
+
+            var result = await this.SendPublicAsync<GeneralResponse<GetFixedTermProductInfoResult>>(GET_FIXED_TERM_PRODUCT, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<PlaceFixedTermOrderResult>?> PlaceFixedTermOrder(string productId, string category, string coin, string amount, string accountType, string orderLinkId, bool? autoInvest = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "productId", productId },
+                { "category", category },
+                { "coin", coin },
+                { "amount", amount },
+                { "accountType", accountType },
+                { "orderLinkId", orderLinkId }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("autoInvest", autoInvest)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<PlaceFixedTermOrderResult>>(PLACE_FIXED_TERM_ORDER, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetFixedTermOrderListResult>?> GetFixedTermOrderList(string? orderType = null, string? productId = null, string? category = null, string? orderId = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("orderType", orderType),
+                ("productId", productId),
+                ("category", category),
+                ("orderId", orderId),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetFixedTermOrderListResult>>(GET_FIXED_TERM_ORDER, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetFixedTermPositionResult>?> GetFixedTermPosition(string? productId = null, string? category = null, string? coin = null)
+        {
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("productId", productId),
+                ("category", category),
+                ("coin", coin)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetFixedTermPositionResult>>(GET_FIXED_TERM_POSITION, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<RedeemFixedTermResult>?> RedeemFixedTerm(string productId, string category, string positionId)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "productId", productId },
+                { "category", category },
+                { "positionId", positionId }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<RedeemFixedTermResult>>(REDEEM_FIXED_TERM, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<SetFixedTermAutoInvestResult>?> SetFixedTermAutoInvest(string productId, string category, string positionId, string status)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "productId", productId },
+                { "category", category },
+                { "positionId", positionId },
+                { "status", status }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<SetFixedTermAutoInvestResult>>(SET_FIXED_TERM_AUTO_INVEST, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenProductResult>?> GetTokenProduct(string coin)
+        {
+            var query = new Dictionary<string, object> { { "coin", coin } };
+            var result = await this.SendPublicAsync<GeneralResponse<GetTokenProductResult>>(GET_TOKEN_PRODUCT, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<PlaceTokenOrderResult>?> PlaceTokenOrder(string coin, string orderLinkId, string orderType, string amount, string accountType)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "coin", coin },
+                { "orderLinkId", orderLinkId },
+                { "orderType", orderType },
+                { "amount", amount },
+                { "accountType", accountType }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<PlaceTokenOrderResult>>(PLACE_TOKEN_ORDER, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenOrderListResult>?> GetTokenOrderList(string coin, string? orderLinkId = null, string? orderId = null, string? orderType = null, long? startTime = null, long? endTime = null, string? cursor = null, int? limit = null)
+        {
+            var query = new Dictionary<string, object> { { "coin", coin } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("orderLinkId", orderLinkId),
+                ("orderId", orderId),
+                ("orderType", orderType),
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("cursor", cursor),
+                ("limit", limit)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetTokenOrderListResult>>(GET_TOKEN_ORDER, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenPositionResult>?> GetTokenPosition(string coin)
+        {
+            var query = new Dictionary<string, object> { { "coin", coin } };
+            var result = await this.SendSignedAsync<GeneralResponse<GetTokenPositionResult>>(GET_TOKEN_POSITION, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenYieldResult>?> GetTokenYield(string coin, long? startTime = null, long? endTime = null, string? cursor = null, int? limit = null)
+        {
+            var query = new Dictionary<string, object> { { "coin", coin } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("cursor", cursor),
+                ("limit", limit)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetTokenYieldResult>>(GET_TOKEN_YIELD, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenHourlyYieldResult>?> GetTokenHourlyYield(string coin, long? startTime = null, long? endTime = null, string? cursor = null, int? limit = null)
+        {
+            var query = new Dictionary<string, object> { { "coin", coin } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("cursor", cursor),
+                ("limit", limit)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetTokenHourlyYieldResult>>(GET_TOKEN_HOURLY_YIELD, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetTokenHistoryAprResult>?> GetTokenHistoryApr(string coin, int range)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "coin", coin },
+                { "range", range }
+            };
+
+            var result = await this.SendPublicAsync<GeneralResponse<GetTokenHistoryAprResult>>(GET_TOKEN_HISTORY_APR, HttpMethod.Get, query: query);
             return result;
         }
     }

--- a/Src/Common/ApiServiceImp/BybitLendingService.cs
+++ b/Src/Common/ApiServiceImp/BybitLendingService.cs
@@ -1,11 +1,21 @@
-﻿using bybit.net.api.Models.Lending;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Lending;
 using bybit.net.api.Services;
-using System.Collections.Specialized;
 
 namespace bybit.net.api.ApiServiceImp
 {
     public class BybitLendingService : BybitApiService
     {
+        public BybitLendingService(string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitLendingService(HttpClient httpClient, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
         public BybitLendingService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
         : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
         {
@@ -18,56 +28,40 @@ namespace bybit.net.api.ApiServiceImp
 
         #region Instituion Lending
         private const string INS_PRODUCT_INFO = "/v5/ins-loan/product-infos";
-        /// <summary>
-        /// This endpoint can be queried without api key and secret, then it returns public product data
-        /// If your uid is bound with OTC loan product, then you can get your private product data by calling the endpoint with api key and secret
-        /// If your uid is not bound with OTC loan product but api key and secret are also passed, it will return public data only
-        /// </summary>
-        /// <param name="productId"></param>
-        /// <returns> Get Product Info </returns>
-        public async Task<string?> GetInsLoanInfo(string? productId = null)
-        {
-            var query = new Dictionary<string, object> { };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("productId", productId)
-            );
-            var result = await this.SendSignedAsync<string>(INS_PRODUCT_INFO, HttpMethod.Get, query: query);
-            return result;
-        }
-
         private const string INS_MARGIN_COIN = "/v5/ins-loan/ensure-tokens-convert";
-        /// <summary>
-        /// This endpoint can be queried without api key and secret, then it returns public margin data
-        /// If your uid is bound with OTC loan product, then you can get your private margin data by calling the endpoint with api key and secret
-        /// If your uid is not bound with OTC loan product but api key and secret are also passed, it will return public data only
-        /// </summary>
-        /// <param name="productId"></param>
-        /// <returns>Get Margin Coin Info</returns>
-        public async Task<string?> GetInsMarginCoinInfo(string? productId = null)
+        private const string INS_LOAN_ORDERS = "/v5/ins-loan/loan-order";
+        private const string INS_LOAN_REPAY_ORDERS = "/v5/ins-loan/repaid-history";
+        private const string INS_LOAN_TO_VALUE = "/v5/ins-loan/ltv-convert";
+        private const string UPDATE_UID_TO_INS_LOAN = "/v5/ins-loan/association-uid";
+        private const string INS_LOAN_REPAY = "/v5/ins-loan/repay-loan";
+
+        public async Task<GeneralResponse<GetInsLoanInfoResult>?> GetInsLoanInfo(string? productId = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("productId", productId)
             );
-            var result = await this.SendSignedAsync<string>(INS_MARGIN_COIN, HttpMethod.Get, query: query);
+
+            var result = await this.SendPublicAsync<GeneralResponse<GetInsLoanInfoResult>>(INS_PRODUCT_INFO, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string INS_LOAN_ORDERS = "/v5/ins-loan/ensure-tokens-convert";
-        /// <summary>
-        /// Get the past 2 years data by default
-        /// Get up to the past 2 years of data
-        /// </summary>
-        /// <param name="orderId"></param>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <param name="limit"></param>
-        /// <returns>Get Loan Orders</returns>
-        public async Task<string?> GetInsLoanOrders(string? orderId = null, long? startTime = null, long? endTime = null, int? limit = null)
+        public async Task<GeneralResponse<GetInsMarginCoinInfoResult>?> GetInsMarginCoinInfo(string? productId = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("productId", productId)
+            );
+
+            var result = await this.SendPublicAsync<GeneralResponse<GetInsMarginCoinInfoResult>>(INS_MARGIN_COIN, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<GetInsLoanOrdersResult>?> GetInsLoanOrders(string? orderId = null, long? startTime = null, long? endTime = null, int? limit = null)
+        {
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("orderId", orderId),
@@ -75,157 +69,121 @@ namespace bybit.net.api.ApiServiceImp
                 ("endTime", endTime),
                 ("limit", limit)
             );
-            var result = await this.SendSignedAsync<string>(INS_LOAN_ORDERS, HttpMethod.Get, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetInsLoanOrdersResult>>(INS_LOAN_ORDERS, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string INS_LOAN_REPAY_ORDERS = "/v5/ins-loan/ensure-tokens-convert";
-        /// <summary>
-        /// Get the past 2 years data by default
-        /// Get up to the past 2 years of data
-        /// </summary>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <param name="limit"></param>
-        /// <returns>Get Repay Orders</returns>
-        public async Task<string?> GetInsLoanRepayOrders(long? startTime = null, long? endTime = null, int? limit = null)
+        public async Task<GeneralResponse<GetInsLoanRepayOrdersResult>?> GetInsLoanRepayOrders(long? startTime = null, long? endTime = null, int? limit = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("startTime", startTime),
                 ("endTime", endTime),
                 ("limit", limit)
             );
-            var result = await this.SendSignedAsync<string>(INS_LOAN_REPAY_ORDERS, HttpMethod.Get, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetInsLoanRepayOrdersResult>>(INS_LOAN_REPAY_ORDERS, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string INS_LOAN_TO_VALUE = "/v5/ins-loan/ltv-convert";
-        /// <summary>
-        /// Get LTV
-        /// </summary>
-        /// <returns> Loan To Value</returns>
-        public async Task<string?> GetInsLoanToValue()
+        public async Task<GeneralResponse<GetInsLoanToValueResult>?> GetInsLoanToValue()
         {
-            var query = new Dictionary<string, object> { };
-            var result = await this.SendSignedAsync<string>(INS_LOAN_TO_VALUE, HttpMethod.Get, query: query);
+            var query = new Dictionary<string, object>();
+            var result = await this.SendSignedAsync<GeneralResponse<GetInsLoanToValueResult>>(INS_LOAN_TO_VALUE, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string UPDATE_UID_TO_INS_LOAN = "/v5/ins-loan/association-uid";
-        /// <summary>
-        /// For the institutional loan product, you can bind new UIDs to the risk unit or unbind UID from the risk unit.
-        /// </summary>
-        /// <returns> Bind Or Unbind UID </returns>
-        public async Task<string?> UpdateInsLoanUID(string uid, OperateType operate)
+        public async Task<GeneralResponse<UpdateInsLoanUidResult>?> UpdateInsLoanUID(string uid, OperateType operate)
         {
-            var query = new Dictionary<string, object> { {"uid", uid}, {"operate", operate.Value} };
-            var result = await this.SendSignedAsync<string>(UPDATE_UID_TO_INS_LOAN, HttpMethod.Post, query: query);
+            var query = new Dictionary<string, object> { { "uid", uid }, { "operate", operate.Value } };
+            var result = await this.SendSignedAsync<GeneralResponse<UpdateInsLoanUidResult>>(UPDATE_UID_TO_INS_LOAN, HttpMethod.Post, query: query);
+            return result;
+        }
+
+        public async Task<GeneralResponse<RepayInsLoanResult>?> RepayInsLoan(string token, string quantity)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "token", token },
+                { "quantity", quantity }
+            };
+
+            var result = await this.SendSignedAsync<GeneralResponse<RepayInsLoanResult>>(INS_LOAN_REPAY, HttpMethod.Post, query: body);
             return result;
         }
         #endregion
 
         #region C2C Lending
         private const string C2C_LENDING_INFO = "/v5/lending/info";
-        /// <summary>
-        /// Get the basic information of lending coins
-        /// All v5/lending APIs need SPOT permission.
-        /// </summary>
-        /// <param name="productId"></param>
-        /// <returns> Get Lending Coin Info </returns>
-        public async Task<string?> GetC2CLendingCoinInfo(string? coin = null)
+        private const string C2C_DEPOSIT_FUND = "/v5/lending/purchase";
+        private const string C2C_REDEEM_FUND = "/v5/lending/redeem";
+        private const string C2C_CANCEL_REDEEM = "/v5/lending/redeem-cancel";
+        private const string C2C_LENDING_ORDERS = "/v5/lending/history-order";
+        private const string C2C_LENDING_ACCOUNT = "/v5/lending/account";
+
+        public async Task<GeneralResponse<GetC2CLendingCoinInfoResult>?> GetC2CLendingCoinInfo(string? coin = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("coin", coin)
             );
-            var result = await this.SendSignedAsync<string>(C2C_LENDING_INFO, HttpMethod.Get, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetC2CLendingCoinInfoResult>>(C2C_LENDING_INFO, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string C2C_DEPOSIT_FUND = "/v5/lending/purchase";
-        /// <summary>
-        /// Lending funds to Bybit asset pool
-        /// normal & UMA account: deduct funds from Spot wallet
-        /// UTA account: deduct funds from Unified wallet
-        /// </summary>
-        /// <param name="coin"></param>
-        /// <param name="quantity"></param>
-        /// <param name="serialNo"></param>
-        /// <returns>Deposit Funds</returns>
-        public async Task<string?> C2CDepositFund(string? coin = null, string? quantity = null, string? serialNo = null)
+        public async Task<GeneralResponse<C2CLendingOrderResult>?> C2CDepositFund(string coin, string quantity, string? serialNo = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>
+            {
+                { "coin", coin },
+                { "quantity", quantity }
+            };
 
             BybitParametersUtils.AddOptionalParameters(query,
-                ("coin", coin),
-                ("quantity", quantity),
                 ("serialNo", serialNo)
             );
-            var result = await this.SendSignedAsync<string>(C2C_DEPOSIT_FUND, HttpMethod.Post, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<C2CLendingOrderResult>>(C2C_DEPOSIT_FUND, HttpMethod.Post, query: query);
             return result;
         }
 
-        private const string C2C_REDEEM_FUND = "/v5/lending/redeem";
-        /// <summary>
-        /// Withdraw funds from the Bybit asset pool.
-        /// There will be two redemption records: one for the redeemed quantity, and the other one is for the total interest occurred.
-        /// </summary>
-        /// <param name="coin"></param>
-        /// <param name="quantity"></param>
-        /// <param name="serialNo"></param>
-        /// <returns>Redeem Funds</returns>
-        public async Task<string?> C2CRedeemFund(string? coin = null, string? quantity = null, string? serialNo = null)
+        public async Task<GeneralResponse<C2CRedeemOrderResult>?> C2CRedeemFund(string coin, string quantity, string? serialNo = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>
+            {
+                { "coin", coin },
+                { "quantity", quantity }
+            };
 
             BybitParametersUtils.AddOptionalParameters(query,
-                ("coin", coin),
-                ("quantity", quantity),
                 ("serialNo", serialNo)
             );
-            var result = await this.SendSignedAsync<string>(C2C_REDEEM_FUND, HttpMethod.Post, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<C2CRedeemOrderResult>>(C2C_REDEEM_FUND, HttpMethod.Post, query: query);
             return result;
         }
 
-        private const string C2C_CANCEL_REDEEM = " /v5/lending/redeem-cancel";
-        /// <summary>
-        /// Withdraw funds from the Bybit asset pool.
-        /// There will be two redemption records: one for the redeemed quantity, and the other one is for the total interest occurred.
-        /// </summary>
-        /// <param name="coin"></param>
-        /// <param name="quantity"></param>
-        /// <param name="serialNo"></param>
-        /// <returns>Redeem Funds</returns>
-        public async Task<string?> C2CCancelRedeem(string? coin = null, string? orderId = null, string? serialNo = null)
+        public async Task<GeneralResponse<C2CCancelRedeemResult>?> C2CCancelRedeem(string? coin = null, string? orderId = null, string? serialNo = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("coin", coin),
                 ("orderId", orderId),
                 ("serialNo", serialNo)
             );
-            var result = await this.SendSignedAsync<string>(C2C_CANCEL_REDEEM, HttpMethod.Post, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<C2CCancelRedeemResult>>(C2C_CANCEL_REDEEM, HttpMethod.Post, query: query);
             return result;
         }
 
-        private const string C2C_LENDING_ORDERS = "/v5/ins-loan/ensure-tokens-convert";
-        /// <summary>
-        /// Get the past 2 years data by default
-        /// Get up to the past 2 years of data
-        /// </summary>
-        /// <param name="coin"></param>
-        /// <param name="orderId"></param>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <param name="limit"></param>
-        /// <returns>Get Loan Orders</returns>
-        public async Task<string?> GetC2CLendingOrders(string? coin = null, string? orderId = null, long? startTime = null, long? endTime = null, int? limit = null, LendingOrderType? orderType = null)
+        public async Task<GeneralResponse<GetC2CLendingOrdersResult>?> GetC2CLendingOrders(string? coin = null, string? orderId = null, long? startTime = null, long? endTime = null, int? limit = null, LendingOrderType? orderType = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("coin", coin),
@@ -235,24 +193,15 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("orderType", orderType?.Value)
             );
-            var result = await this.SendSignedAsync<string>(C2C_LENDING_ORDERS, HttpMethod.Get, query: query);
+
+            var result = await this.SendSignedAsync<GeneralResponse<GetC2CLendingOrdersResult>>(C2C_LENDING_ORDERS, HttpMethod.Get, query: query);
             return result;
         }
 
-        private const string C2C_LENDING_ACCOUNT = "/v5/lending/account";
-        /// <summary>
-        /// Get Lending Account Info
-        /// </summary>
-        /// <param name="coin"></param>
-        /// <returns>Get Lending Account Info</returns>
-        public async Task<string?> GetC2CLendingOrders(string? coin = null)
+        public async Task<GeneralResponse<GetC2CLendingAccountInfoResult>?> GetC2CLendingAccountInfo(string coin)
         {
-            var query = new Dictionary<string, object> { };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("coin", coin)
-            );
-            var result = await this.SendSignedAsync<string>(C2C_LENDING_ACCOUNT, HttpMethod.Get, query: query);
+            var query = new Dictionary<string, object> { { "coin", coin } };
+            var result = await this.SendSignedAsync<GeneralResponse<GetC2CLendingAccountInfoResult>>(C2C_LENDING_ACCOUNT, HttpMethod.Get, query: query);
             return result;
         }
         #endregion

--- a/Src/Common/ApiServiceImp/BybitMarketDataService.cs
+++ b/Src/Common/ApiServiceImp/BybitMarketDataService.cs
@@ -1,8 +1,9 @@
-﻿using bybit.net.api.Models;
+using bybit.net.api.Models;
 using bybit.net.api.Models.Market;
 using bybit.net.api.Models.Trade;
 using bybit.net.api.Services;
-
+using System;
+using System.Collections.Generic;
 
 namespace bybit.net.api.ApiServiceImp
 {
@@ -21,228 +22,195 @@ namespace bybit.net.api.ApiServiceImp
         private const string CHECK_SERVER_TIME = "/v5/market/time";
 
         /// <summary>
-        /// Get Bybit Server Time.<para />
+        /// Get Bybit server time.
         /// </summary>
-        /// <returns>Bybit server UTC timestamp.</returns>
-        public async Task<string?> CheckServerTime()
+        public async Task<GeneralResponse<GetBybitServerTimeResult>?> GetServerTime()
         {
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetBybitServerTimeResult>>(
                 CHECK_SERVER_TIME,
                 HttpMethod.Get);
-
-            return result;
         }
 
-        private const string MAKRKET_KLINE = "/v5/market/kline";
+        /// <summary>
+        /// Backward-compatible alias for GetServerTime().
+        /// </summary>
+        public Task<GeneralResponse<GetBybitServerTimeResult>?> CheckServerTime()
+        {
+            return GetServerTime();
+        }
+
+        private const string MARKET_KLINE = "/v5/market/kline";
 
         /// <summary>
-        /// Query for historical mark price klines. Charts are returned in groups based on the requested interval.
-        /// Covers: USDT perpetual / USDC contract / Inverse contract
+        /// Query historical klines.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="interval"></param>
-        /// <param name="start"></param>
-        /// <param name="end"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market kline</returns>
-        public async Task<string?> GetMarketKline(Category category, string symbol, MarketInterval interval, long? start = null, long? end = null, int? limit = null)
+        public async Task<GeneralResponse<MarketKLineResult>?> GetMarketKline(Category? category = null, string symbol = "", MarketInterval interval = default, long? start = null, long? end = null, int? limit = null)
         {
             var query = new Dictionary<string, object>
-                        {
-                    { "category", category },
-                    { "symbol", symbol },
-                    { "interval", interval }, };
+            {
+                { "symbol", symbol },
+                { "interval", interval }
+            };
+
             BybitParametersUtils.AddOptionalParameters(query,
+                ("category", category),
                 ("start", start),
                 ("end", end),
                 ("limit", limit)
             );
-            var result = await SendPublicAsync<string>(
-                MAKRKET_KLINE,
+
+            return await SendPublicAsync<GeneralResponse<MarketKLineResult>>(
+                MARKET_KLINE,
                 HttpMethod.Get,
                 query: query);
-
-            return result;
         }
 
         private const string MARK_PRICE_KLINE = "/v5/market/mark-price-kline";
+
         /// <summary>
-        /// Query for historical mark price klines. Charts are returned in groups based on the requested interval.
-        /// Covers: USDT perpetual / USDC contract / Inverse contract
+        /// Query historical mark price klines.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="interval"></param>
-        /// <param name="start"></param>
-        /// <param name="end"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market kline</returns>
-        public async Task<string?> GetMarkPriceKline(Category category, string symbol, MarketInterval interval, long? start = null, long? end = null, int? limit = null)
+        public async Task<GeneralResponse<MarketKLineResult>?> GetMarkPriceKline(Category? category = null, string symbol = "", MarketInterval interval = default, long? start = null, long? end = null, int? limit = null)
         {
             var query = new Dictionary<string, object>
-                        {
-                    { "category", category },
-                    { "symbol", symbol },
-                    { "interval", interval }, };
+            {
+                { "symbol", symbol },
+                { "interval", interval }
+            };
+
             BybitParametersUtils.AddOptionalParameters(query,
+                ("category", category),
                 ("start", start),
                 ("end", end),
                 ("limit", limit)
             );
-            var result = await SendPublicAsync<string>(
+
+            return await SendPublicAsync<GeneralResponse<MarketKLineResult>>(
                 MARK_PRICE_KLINE,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string INDEX_PRICE_KLINE = "/v5/market/index-price-kline";
+
         /// <summary>
-        /// Query for historical index price klines. Charts are returned in groups based on the requested interval.
-        /// Covers: USDT perpetual / USDC contract / Inverse contract
+        /// Query historical index price klines.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="interval"></param>
-        /// <param name="start"></param>
-        /// <param name="end"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market kline</returns>
-        public async Task<string?> GetIndexPriceKline(Category category, string symbol, MarketInterval interval, long? start = null, long? end = null, int? limit = null)
+        public async Task<GeneralResponse<MarketKLineResult>?> GetIndexPriceKline(Category? category = null, string symbol = "", MarketInterval interval = default, long? start = null, long? end = null, int? limit = null)
         {
             var query = new Dictionary<string, object>
-                        {
-                    { "category", category },
-                    { "symbol", symbol },
-                    { "interval", interval }, };
+            {
+                { "symbol", symbol },
+                { "interval", interval }
+            };
+
             BybitParametersUtils.AddOptionalParameters(query,
-                 ("start", start),
-                 ("end", end),
-                 ("limit", limit)
-             );
-            var result = await SendPublicAsync<string>(
+                ("category", category),
+                ("start", start),
+                ("end", end),
+                ("limit", limit)
+            );
+
+            return await SendPublicAsync<GeneralResponse<MarketKLineResult>>(
                 INDEX_PRICE_KLINE,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string PREMIUM_INDEX_PRICE_KLINE = "/v5/market/premium-index-price-kline";
+
         /// <summary>
-        /// Query for historical index premium price klines. Charts are returned in groups based on the requested interval.
-        /// Covers: USDT perpetual / USDC contract / Inverse contract
+        /// Query historical premium index price klines.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="interval"></param>
-        /// <param name="start"></param>
-        /// <param name="end"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market kline</returns>
-        public async Task<string?> GetPremiumIndexPriceKline(Category category, string symbol, MarketInterval interval, long? start = null, long? end = null, int? limit = null)
+        public async Task<GeneralResponse<MarketKLineResult>?> GetPremiumIndexPriceKline(Category? category = null, string symbol = "", MarketInterval interval = default, long? start = null, long? end = null, int? limit = null)
         {
             var query = new Dictionary<string, object>
-                        {
-                    { "category", category },
-                    { "symbol", symbol },
-                    { "interval", interval }, };
+            {
+                { "symbol", symbol },
+                { "interval", interval }
+            };
+
             BybitParametersUtils.AddOptionalParameters(query,
-                 ("start", start),
-                 ("end", end),
-                 ("limit", limit)
-             );
-            var result = await SendPublicAsync<string>(
+                ("category", category),
+                ("start", start),
+                ("end", end),
+                ("limit", limit)
+            );
+
+            return await SendPublicAsync<GeneralResponse<MarketKLineResult>>(
                 PREMIUM_INDEX_PRICE_KLINE,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string INSTRUMENT_INFO = "/v5/market/instruments-info";
+
         /// <summary>
-        /// use for the instrument specification of online trading pairs.
-        /// Covers: Spot / USDT perpetual / USDC contract / Inverse contract / Option
-        ///Spot does not support pagination, so limit, cursor are invalid.
-        ///When query by baseCoin, regardless of category= linear or inverse, the result will have USDT perpetual, USDC contract and Inverse contract symbols.
+        /// Get instrument specification for online trading pairs.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="status"></param>
-        /// <param name="baseCoin"></param>
-        /// <param name="cursor"></param>
-        /// <param name="limit"></param>
-        /// <returns>Instrument Info</returns>
-        public async Task<string?> GetInstrumentInfo(Category category, string? symbol = null, InstrumentStatus? status = null, string? baseCoin = null, int? limit = null, string? cursor = null)
-        {
-            var query = new Dictionary<string, object> { { "category", category },};
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("status", status?.Status),
-                ("symbol", symbol),
-                ("baseCoin", baseCoin),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await SendPublicAsync<string>(
-                INSTRUMENT_INFO,
-                HttpMethod.Get,
-                query: query
-                );
-
-            return result;
-        }
-
-        private const string MARKET_ORDERBOOK = "/v5/market/orderbook";
-        /// <summary>
-        /// Query for orderbook depth data.
-        ///Covers: Spot / USDT perpetual / USDC contract / Inverse contract / Option
-        ///future: 200-level of orderbook data
-        ///spot: 50-level of orderbook data
-        ///option: 25-level of orderbook data
-        /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market Orderbook</returns>
-        public async Task<string?> GetMarketOrderbook(Category category, string? symbol = null, int? limit = null)
+        public async Task<GeneralResponse<GetInstrumentsInfoResult>?> GetInstrumentInfo(Category category, string? symbol = null, string? symbolType = null, InstrumentStatus? status = null, string? baseCoin = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("symbol", symbol),
+                ("symbolType", symbolType),
+                ("status", status?.Status),
+                ("baseCoin", baseCoin),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetInstrumentsInfoResult>>(
+                INSTRUMENT_INFO,
+                HttpMethod.Get,
+                query: query);
+        }
+
+        private const string MARKET_ORDERBOOK = "/v5/market/orderbook";
+
+        /// <summary>
+        /// Query for orderbook depth data.
+        /// </summary>
+        public async Task<GeneralResponse<GetOrderbookResult>?> GetMarketOrderbook(Category category, string symbol, int? limit = null)
+        {
+            var query = new Dictionary<string, object> { { "category", category }, { "symbol", symbol } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
                 ("limit", limit)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetOrderbookResult>>(
                 MARKET_ORDERBOOK,
                 HttpMethod.Get,
-                query: query
-                );
+                query: query);
+        }
 
-            return result;
+        private const string RPI_ORDERBOOK = "/v5/market/rpi_orderbook";
+
+        /// <summary>
+        /// Query RPI orderbook depth data.
+        /// </summary>
+        public async Task<GeneralResponse<GetOrderbookResult>?> GetRpiOrderbook(string symbol, int limit, Category? category = null)
+        {
+            var query = new Dictionary<string, object> { { "symbol", symbol }, { "limit", limit } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("category", category)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetOrderbookResult>>(
+                RPI_ORDERBOOK,
+                HttpMethod.Get,
+                query: query);
         }
 
         private const string MARKET_TICKERS = "/v5/market/tickers";
+
         /// <summary>
-        /// Get Tickers
-        ///Query for the latest price snapshot, best bid/ask price, and trading volume in the last 24 hours.
-        ///Covers: Spot / USDT perpetual / USDC contract / Inverse contract / Option
-        ///If category = option, symbol or baseCoin must be passed.
+        /// Get latest tickers.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="baseCoin"></param>
-        /// <param name="expDate"></param>
-        /// <returns>Market Tickers</returns>
-        public async Task<string?> GetMarketTickers(Category category, string? symbol = null, string? baseCoin = null, string? expDate = null)
+        public async Task<GeneralResponse<MarketTickerResult>?> GetMarketTickers(Category category, string? symbol = null, string? baseCoin = null, string? expDate = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
@@ -252,29 +220,18 @@ namespace bybit.net.api.ApiServiceImp
                 ("expDate", expDate)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<MarketTickerResult>>(
                 MARKET_TICKERS,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string MARKET_FUNDING_HISTORY = "/v5/market/funding/history";
+
         /// <summary>
-        /// Get Tickers
-        ///Query for historical funding rates.Each symbol has a different funding interval.For example, if the interval is 8 hours and the current time is UTC 12, then it returns the last funding rate, which settled at UTC 8.
-        ///To query the funding rate interval, please refer to the instruments-info endpoint.
-        ///Covers: USDT and USDC perpetual / Inverse perpetual
+        /// Get historical funding rates.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market Funding History</returns>
-        public async Task<string?> GetMarketFundingHistory(Category category, string symbol, long? startTime = null, long? endTime = null, int? limit = null)
+        public async Task<GeneralResponse<FundingRateResult>?> GetMarketFundingHistory(Category category, string symbol, long? startTime = null, long? endTime = null, int? limit = null)
         {
             var query = new Dictionary<string, object> { { "category", category }, { "symbol", symbol } };
 
@@ -284,147 +241,109 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<FundingRateResult>>(
                 MARKET_FUNDING_HISTORY,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string MARKET_RECENT_TRADE = "/v5/market/recent-trade";
+
         /// <summary>
-        /// Get Public Recent Trading History Query recent public trading data in Bybit.
-        ///Covers: Spot / USDT perpetual / USDC contract / Inverse contract / Option
-        ///You can download archived historical trades here: USDT Perpetual, Inverse Perpetual & Inverse Futures Spot
+        /// Get public recent trading history.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="baseCoin"></param>
-        /// <param name="optionType"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market Recent Trades</returns>
-        public async Task<string?> GetMarketRecentTrade(Category category, string symbol, string? baseCoin = null, OptionType? optionType = null, int? limit = null)
-        {
-            var query = new Dictionary<string, object> { { "category", category }, };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                 ("symbol", symbol),
-                 ("baseCoin", baseCoin),
-                 ("optionType", optionType?.Value),
-                ("limit", limit)
-            );
-
-            var result = await SendPublicAsync<string>(
-                MARKET_RECENT_TRADE,
-                HttpMethod.Get,
-                query: query
-                );
-
-            return result;
-        }
-
-        private const string MARKET_OPEN_INTEREST = "/v5/market/open-interest";
-        /// <summary>
-        /// Get the open interest of each symbol.
-        ///Covers: USDT perpetual / USDC contract / Inverse contract
-        ///Returns single side data
-        ///The upper limit time you can query is the launch time of the symbol.
-        /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="intervalTime"></param>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <param name="limit"></param>
-        /// <returns>Market Open Interest</returns>
-        public async Task<string?> GetMarketOpenInterest(Category category, string symbol, MarketIntervalTime intervalTime, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
-        {
-            var query = new Dictionary<string, object> { { "category", category }, { "symbol", symbol }, { "intervalTime", intervalTime.Value } };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                 ("startTime", startTime),
-                 ("endTime", endTime),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await SendPublicAsync<string>(
-                MARKET_OPEN_INTEREST,
-                HttpMethod.Get,
-                query: query
-                );
-
-            return result;
-        }
-
-        private const string MARKET_HISTORICAL_VOLATILITY = "/v5/market/historical-volatility";
-        /// <summary>
-        /// Query option historical volatility
-        ///Covers: Option
-        ///The data is hourly.
-        ///If both startTime and endTime are not specified, it will return the most recent 1 hours worth of data.
-        ///startTime and endTime are a pair of params. Either both are passed or they are not passed at all.
-        ///This endpoint can query the last 2 years worth of data, but make sure[endTime - startTime] <= 30 days.
-        /// </summary>
-        /// <param name="category"></param>
-        /// <param name="baseCoin"></param>
-        /// <param name="period"></param>
-        /// <param name="startTime"></param>
-        /// <param name="endTime"></param>
-        /// <returns>Market Historical Volatility</returns>
-        public async Task<string?> GetMarketHistoricalVolatility(Category category, string? baseCoin = null, string? period = null, long? startTime = null, long? endTime = null)
+        public async Task<GeneralResponse<GetRecentTradeResult>?> GetMarketRecentTrade(Category category, string? symbol = null, string? baseCoin = null, OptionType? optionType = null, int? limit = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
             BybitParametersUtils.AddOptionalParameters(query,
+                ("symbol", symbol),
                 ("baseCoin", baseCoin),
-                ("period", period),
-                 ("startTime", startTime),
-                 ("endTime", endTime)
+                ("optionType", optionType?.Value),
+                ("limit", limit)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetRecentTradeResult>>(
+                MARKET_RECENT_TRADE,
+                HttpMethod.Get,
+                query: query);
+        }
+
+        private const string MARKET_OPEN_INTEREST = "/v5/market/open-interest";
+
+        /// <summary>
+        /// Get open interest data.
+        /// </summary>
+        public async Task<GeneralResponse<GetOpenInterestResult>?> GetMarketOpenInterest(Category category, string symbol, MarketIntervalTime intervalTime, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object> { { "category", category }, { "symbol", symbol }, { "intervalTime", intervalTime.Value } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("startTime", startTime),
+                ("endTime", endTime),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetOpenInterestResult>>(
+                MARKET_OPEN_INTEREST,
+                HttpMethod.Get,
+                query: query);
+        }
+
+        private const string MARKET_HISTORICAL_VOLATILITY = "/v5/market/historical-volatility";
+
+        /// <summary>
+        /// Query option historical volatility.
+        /// </summary>
+        public async Task<GeneralResponse<GetHistoricalVolatilityResult>?> GetMarketHistoricalVolatility(Category category, string? baseCoin = null, string? quoteCoin = null, int? period = null, long? startTime = null, long? endTime = null)
+        {
+            if (category.ToString() != Category.OPTION.ToString())
+            {
+                throw new ArgumentException("Historical volatility is only available for option category.", nameof(category));
+            }
+
+            var query = new Dictionary<string, object> { { "category", category } };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("baseCoin", baseCoin),
+                ("quoteCoin", quoteCoin),
+                ("period", period),
+                ("startTime", startTime),
+                ("endTime", endTime)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetHistoricalVolatilityResult>>(
                 MARKET_HISTORICAL_VOLATILITY,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string MARKET_INSURANCE = "/v5/market/insurance";
+
         /// <summary>
-        /// Query for Bybit insurance pool data(BTC/USDT/USDC etc). The data is updated every 24 hours.
+        /// Query insurance pool data.
         /// </summary>
-        /// <param name="coin"></param>
-        /// <returns>Market Insurance</returns>
-        public async Task<string?> GetMarketInsurance(string? coin = null)
+        public async Task<GeneralResponse<GetInsurancePoolResult>?> GetMarketInsurance(string? coin = null)
         {
-            var query = new Dictionary<string, object> { };
+            var query = new Dictionary<string, object>();
 
             BybitParametersUtils.AddOptionalParameters(query,
-                 ("coin", coin)
+                ("coin", coin)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetInsurancePoolResult>>(
                 MARKET_INSURANCE,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string MARKET_RISK_LIMIT = "/v5/market/risk-limit";
+
         /// <summary>
-        /// Query for Bybit insurance pool data(BTC/USDT/USDC etc). The data is updated every 24 hours.
+        /// Query risk limit margin parameters.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <returns>Market Risk Limit</returns>
-        public async Task<string?> GetMarketRiskLimit(Category category, string? symbol = null)
+        public async Task<GeneralResponse<GetRiskLimitResult>?> GetMarketRiskLimit(Category category, string? symbol = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
@@ -432,27 +351,18 @@ namespace bybit.net.api.ApiServiceImp
                  ("symbol", symbol)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetRiskLimitResult>>(
                 MARKET_RISK_LIMIT,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string MARKET_DELIVERY_PRICE = "/v5/market/delivery-price";
+
         /// <summary>
-        /// Get the delivery price.
-        /// Covers: USDC futures / Inverse futures / Option
+        /// Get delivery price.
         /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="baseCoin"></param>
-        /// <param name="limit"></param>
-        /// <param name="cursor"></param>
-        /// <returns>Market Delivery Price</returns>
-        public async Task<string?> GetMarketDeliveryPrice(Category category, string? symbol = null, string? baseCoin = null, string? settleCoin = null, int? limit =null, string? cursor = null)
+        public async Task<GeneralResponse<GetDeliveryPriceResult>?> GetMarketDeliveryPrice(Category category, string? symbol = null, string? baseCoin = null, string? settleCoin = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category } };
 
@@ -464,27 +374,24 @@ namespace bybit.net.api.ApiServiceImp
                  ("settleCoin", settleCoin)
             );
 
-            var result = await SendPublicAsync<string>(
+            return await SendPublicAsync<GeneralResponse<GetDeliveryPriceResult>>(
                 MARKET_DELIVERY_PRICE,
                 HttpMethod.Get,
-                query: query
-                );
-
-            return result;
+                query: query);
         }
 
         private const string GET_NEW_DELIVERY_PRICE = "/v5/market/new-delivery-price";
 
         /// <summary>
-        /// Get New Delivery Price
-        /// Get historical option delivery prices. Data may be delayed by ~1 minute after settlement.
+        /// Get historical option delivery prices.
         /// </summary>
-        /// <param name="category">Product type. Valid: "option"</param>
-        /// <param name="baseCoin">Base coin, e.g., BTC</param>
-        /// <param name="settleCoin">Settle coin. Default: USDT</param>
-        /// <returns></returns>
-        public async Task<string?> GetNewDeliveryPrice(string category, string baseCoin, string? settleCoin = null)
+        public async Task<GeneralResponse<GetNewDeliveryPriceResult>?> GetNewDeliveryPrice(Category category, string baseCoin, string? settleCoin = null)
         {
+            if (category.ToString() != Category.OPTION.ToString())
+            {
+                throw new ArgumentException("New delivery price is only available for option category.", nameof(category));
+            }
+
             var query = new Dictionary<string, object>
             {
                 { "category", category },
@@ -495,33 +402,18 @@ namespace bybit.net.api.ApiServiceImp
                 ("settleCoin", settleCoin)
             );
 
-            var result = await this.SendPublicAsync<string>(GET_NEW_DELIVERY_PRICE, HttpMethod.Get, query: query);
-            return result;
+            return await SendPublicAsync<GeneralResponse<GetNewDeliveryPriceResult>>(
+                GET_NEW_DELIVERY_PRICE,
+                HttpMethod.Get,
+                query: query);
         }
-
 
         private const string GET_LONG_SHORT_RATIO = "/v5/market/account-ratio";
 
         /// <summary>
-        /// Get Long Short Ratio
-        /// Returns account long/short ratio over the requested period.
+        /// Get long short ratio.
         /// </summary>
-        /// <param name="category">linear or inverse</param>
-        /// <param name="symbol">e.g., BTCUSDT</param>
-        /// <param name="period">5min, 15min, 30min, 1h, 4h, 1d</param>
-        /// <param name="startTime">Timestamp (ms)</param>
-        /// <param name="endTime">Timestamp (ms)</param>
-        /// <param name="limit">[1,500], default 50</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetLongShortRatio(
-            string category,
-            string symbol,
-            string period,
-            string? startTime = null,
-            string? endTime = null,
-            int? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetLongShortRatioResult>?> GetLongShortRatio(Category category, string symbol, string period, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>
             {
@@ -537,20 +429,18 @@ namespace bybit.net.api.ApiServiceImp
                 ("cursor", cursor)
             );
 
-            var result = await this.SendPublicAsync<string>(GET_LONG_SHORT_RATIO, HttpMethod.Get, query: query);
-            return result;
+            return await SendPublicAsync<GeneralResponse<GetLongShortRatioResult>>(
+                GET_LONG_SHORT_RATIO,
+                HttpMethod.Get,
+                query: query);
         }
 
         private const string GET_ORDER_PRICE_LIMIT = "/v5/market/price-limit";
 
         /// <summary>
-        /// Get Order Price Limit
-        /// Returns current highest bid and lowest ask price limits.
+        /// Get order price limit.
         /// </summary>
-        /// <param name="symbol">Symbol name, e.g., BTCUSDT</param>
-        /// <param name="category">spot, linear, inverse. Default: linear if omitted</param>
-        /// <returns></returns>
-        public async Task<string?> GetOrderPriceLimit(string symbol, string? category = null)
+        public async Task<GeneralResponse<GetOrderPriceLimitResult>?> GetOrderPriceLimit(string symbol, Category? category = null)
         {
             var query = new Dictionary<string, object>
             {
@@ -561,9 +451,69 @@ namespace bybit.net.api.ApiServiceImp
                 ("category", category)
             );
 
-            var result = await this.SendPublicAsync<string>(GET_ORDER_PRICE_LIMIT, HttpMethod.Get, query: query);
-            return result;
+            return await SendPublicAsync<GeneralResponse<GetOrderPriceLimitResult>>(
+                GET_ORDER_PRICE_LIMIT,
+                HttpMethod.Get,
+                query: query);
         }
 
+        private const string GET_INDEX_PRICE_COMPONENTS = "/v5/market/index-price-components";
+
+        /// <summary>
+        /// Get index price components.
+        /// </summary>
+        public async Task<GeneralResponse<GetIndexPriceComponentsResult>?> GetIndexPriceComponents(string indexName)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "indexName", indexName }
+            };
+
+            return await SendPublicAsync<GeneralResponse<GetIndexPriceComponentsResult>>(
+                GET_INDEX_PRICE_COMPONENTS,
+                HttpMethod.Get,
+                query: query);
+        }
+
+        private const string GET_ADL_ALERT = "/v5/market/adlAlert";
+
+        /// <summary>
+        /// Get ADL alert data.
+        /// </summary>
+        public async Task<GeneralResponse<GetAdlAlertResult>?> GetAdlAlert(string? symbol = null)
+        {
+            var query = new Dictionary<string, object>();
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("symbol", symbol)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetAdlAlertResult>>(
+                GET_ADL_ALERT,
+                HttpMethod.Get,
+                query: query);
+        }
+
+        private const string GET_FEE_GROUP_INFO = "/v5/market/fee-group-info";
+
+        /// <summary>
+        /// Get fee group structure.
+        /// </summary>
+        public async Task<GeneralResponse<GetFeeGroupInfoResult>?> GetFeeGroupInfo(string productType, string? groupId = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "productType", productType }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("groupId", groupId)
+            );
+
+            return await SendPublicAsync<GeneralResponse<GetFeeGroupInfoResult>>(
+                GET_FEE_GROUP_INFO,
+                HttpMethod.Get,
+                query: query);
+        }
     }
 }

--- a/Src/Common/ApiServiceImp/BybitNewCryptoLoanService.cs
+++ b/Src/Common/ApiServiceImp/BybitNewCryptoLoanService.cs
@@ -1,14 +1,21 @@
-﻿using bybit.net.api.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using bybit.net.api.Models;
+using bybit.net.api.Models.CryptoLoan;
+using bybit.net.api.Services;
 
 namespace bybit.net.api.ApiServiceImp
 {
     public class BybitNewCryptoLoanService : BybitApiService
     {
+        public BybitNewCryptoLoanService(string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+        : this(httpClient: new HttpClient(), url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
+        public BybitNewCryptoLoanService(HttpClient httpClient, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
+            : base(httpClient: httpClient, url: url, recvWindow: recvWindow, debugMode: debugMode)
+        {
+        }
+
         public BybitNewCryptoLoanService(string apiKey, string apiSecret, string? url = null, string recvWindow = BybitConstants.DEFAULT_REC_WINDOW, bool debugMode = false)
         : this(httpClient: new HttpClient(), apiKey: apiKey, apiSecret: apiSecret, url: url, recvWindow: recvWindow, debugMode: debugMode)
         {
@@ -20,74 +27,64 @@ namespace bybit.net.api.ApiServiceImp
         }
 
         private const string GET_BORROWABLE_COINS = "/v5/crypto-loan-common/loanable-data";
+        private const string GET_COLLATERAL_COINS = "/v5/crypto-loan-common/collateral-data";
+        private const string GET_MAX_ALLOWED_COLLATERAL_REDUCTION_AMOUNT = "/v5/crypto-loan-common/max-collateral-amount";
+        private const string GET_MAX_LOAN_AMOUNT = "/v5/crypto-loan-common/max-loan";
+        private const string ADJUST_COLLATERAL_AMOUNT = "/v5/crypto-loan-common/adjust-ltv";
+        private const string GET_COLLATERAL_ADJUSTMENT_HISTORY = "/v5/crypto-loan-common/adjustment-history";
+        private const string GET_CRYPTO_LOAN_POSITION = "/v5/crypto-loan-common/position";
 
-        /// <summary>
-        /// Get Borrowable Coins
-        /// Public endpoint. Lists borrowable coins and limits.
-        /// </summary>
-        /// <param name="vipLevel">VIP0..VIP5, VIP99, PRO1..PRO6</param>
-        /// <param name="currency">Coin, uppercase</param>
-        /// <returns></returns>
-        public async Task<string?> GetBorrowableCoins(string? vipLevel = null, string? currency = null)
+        private const string BORROW_FLEXIBLE_LOAN = "/v5/crypto-loan-flexible/borrow";
+        private const string REPAY_FLEXIBLE_LOAN = "/v5/crypto-loan-flexible/repay";
+        private const string REPAY_COLLATERAL_FLEXIBLE = "/v5/crypto-loan-flexible/repay-collateral";
+        private const string GET_FLEXIBLE_LOANS = "/v5/crypto-loan-flexible/ongoing-coin";
+        private const string GET_FLEXIBLE_BORROW_ORDERS_HISTORY = "/v5/crypto-loan-flexible/borrow-history";
+        private const string GET_FLEXIBLE_REPAYMENT_ORDERS_HISTORY = "/v5/crypto-loan-flexible/repayment-history";
+
+        private const string GET_SUPPLYING_MARKET_FIXED = "/v5/crypto-loan-fixed/supply-order-quote";
+        private const string GET_BORROWING_MARKET_FIXED = "/v5/crypto-loan-fixed/borrow-order-quote";
+        private const string CREATE_BORROW_ORDER_FIXED = "/v5/crypto-loan-fixed/borrow";
+        private const string CREATE_SUPPLY_ORDER_FIXED = "/v5/crypto-loan-fixed/supply";
+        private const string CANCEL_BORROW_ORDER_FIXED = "/v5/crypto-loan-fixed/borrow-order-cancel";
+        private const string CANCEL_SUPPLY_ORDER_FIXED = "/v5/crypto-loan-fixed/supply-order-cancel";
+        private const string GET_BORROW_CONTRACT_INFO_FIXED = "/v5/crypto-loan-fixed/borrow-contract-info";
+        private const string GET_SUPPLY_CONTRACT_INFO_FIXED = "/v5/crypto-loan-fixed/supply-contract-info";
+        private const string GET_BORROW_ORDER_INFO_FIXED = "/v5/crypto-loan-fixed/borrow-order-info";
+        private const string GET_SUPPLY_ORDER_INFO_FIXED = "/v5/crypto-loan-fixed/supply-order-info";
+        private const string REPAY_FIXED_LOAN = "/v5/crypto-loan-fixed/fully-repay";
+        private const string REPAY_COLLATERAL_FIXED = "/v5/crypto-loan-fixed/repay-collateral";
+        private const string GET_REPAYMENT_HISTORY_FIXED = "/v5/crypto-loan-fixed/repayment-history";
+        private const string RENEW_FIXED_LOAN = "/v5/crypto-loan-fixed/renew";
+        private const string GET_RENEW_ORDER_INFO_FIXED = "/v5/crypto-loan-fixed/renew-info";
+
+        public async Task<GeneralResponse<GetBorrowableCoinsResult>?> GetBorrowableCoins(string? vipLevel = null, string? currency = null)
         {
             var query = new Dictionary<string, object>();
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("vipLevel", vipLevel),
-                ("currency", currency)
-            );
-
-            var result = await this.SendPublicAsync<string>(GET_BORROWABLE_COINS, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("vipLevel", vipLevel), ("currency", currency));
+            return await SendPublicAsync<GeneralResponse<GetBorrowableCoinsResult>>(GET_BORROWABLE_COINS, HttpMethod.Get, query: query);
         }
 
-        private const string GET_COLLATERAL_COINS = "/v5/crypto-loan-common/collateral-data";
-
-        /// <summary>
-        /// Get Collateral Coins
-        /// Public. Collateral ratios and liquidation priority.
-        /// </summary>
-        /// <param name="currency">Optional coin, uppercase</param>
-        /// <returns></returns>
-        public async Task<string?> GetCollateralCoins(string? currency = null)
+        public async Task<GeneralResponse<GetCollateralCoinsResult>?> GetCollateralCoins(string? currency = null)
         {
             var query = new Dictionary<string, object>();
             BybitParametersUtils.AddOptionalParameters(query, ("currency", currency));
-
-            var result = await this.SendPublicAsync<string>(GET_COLLATERAL_COINS, HttpMethod.Get, query: query);
-            return result;
+            return await SendPublicAsync<GeneralResponse<GetCollateralCoinsResult>>(GET_COLLATERAL_COINS, HttpMethod.Get, query: query);
         }
 
-        private const string GET_MAX_ALLOWED_COLLATERAL_REDUCTION_AMOUNT = "/v5/crypto-loan-common/max-collateral-amount";
-
-        /// <summary>
-        /// Get Max. Allowed Collateral Reduction Amount
-        /// Retrieve the maximum redeemable amount of your collateral asset based on LTV. Auth required.
-        /// </summary>
-        /// <param name="currency">Collateral coin</param>
-        /// <returns></returns>
-        public async Task<string?> GetMaxAllowedCollateralReductionAmount(string currency)
+        public async Task<GeneralResponse<GetMaxAllowedCollateralReductionAmountResult>?> GetMaxAllowedCollateralReductionAmount(string currency)
         {
             var query = new Dictionary<string, object> { { "currency", currency } };
-
-            var result = await this.SendSignedAsync<string>(
-                GET_MAX_ALLOWED_COLLATERAL_REDUCTION_AMOUNT,
-                HttpMethod.Get,
-                query: query
-            );
-            return result;
+            return await SendSignedAsync<GeneralResponse<GetMaxAllowedCollateralReductionAmountResult>>(GET_MAX_ALLOWED_COLLATERAL_REDUCTION_AMOUNT, HttpMethod.Get, query: query);
         }
 
-        private const string ADJUST_COLLATERAL_AMOUNT = "/v5/crypto-loan-common/adjust-ltv";
+        public async Task<GeneralResponse<GetMaxLoanAmountResult>?> GetMaxLoanAmount(string currency, List<MaxLoanCollateralItem>? collateralList = null)
+        {
+            var body = new Dictionary<string, object> { { "currency", currency } };
+            BybitParametersUtils.AddOptionalParameters(body, ("collateralList", collateralList));
+            return await SendSignedAsync<GeneralResponse<GetMaxLoanAmountResult>>(GET_MAX_LOAN_AMOUNT, HttpMethod.Post, query: body);
+        }
 
-        /// <summary>
-        /// Adjust Collateral Amount
-        /// Increase or reduce collateral. Funds are moved to/from Funding wallet.
-        /// </summary>
-        /// <param name="currency">Collateral coin</param>
-        /// <param name="amount">Adjustment amount</param>
-        /// <param name="direction">"0": add collateral; "1": reduce collateral</param>
-        /// <returns></returns>
-        public async Task<string?> AdjustCollateralAmount(string currency, string amount, string direction)
+        public async Task<GeneralResponse<AdjustCollateralAmountResult>?> AdjustCollateralAmount(string currency, string amount, string direction)
         {
             var body = new Dictionary<string, object>
             {
@@ -95,124 +92,39 @@ namespace bybit.net.api.ApiServiceImp
                 { "amount", amount },
                 { "direction", direction }
             };
-
-            var result = await this.SendSignedAsync<string>(ADJUST_COLLATERAL_AMOUNT, HttpMethod.Post, query: body);
-            return result;
+            return await SendSignedAsync<GeneralResponse<AdjustCollateralAmountResult>>(ADJUST_COLLATERAL_AMOUNT, HttpMethod.Post, query: body);
         }
 
-        private const string GET_COLLATERAL_ADJUSTMENT_HISTORY = "/v5/crypto-loan-common/adjustment-history";
-
-        /// <summary>
-        /// Get Collateral Adjustment History
-        /// Query LTV adjustment history. Auth required.
-        /// </summary>
-        /// <param name="adjustId">Collateral adjustment transaction ID</param>
-        /// <param name="collateralCurrency">Collateral coin</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetCollateralAdjustmentHistory(
-            string? adjustId = null,
-            string? collateralCurrency = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetCollateralAdjustmentHistoryResult>?> GetCollateralAdjustmentHistory(string? adjustId = null, string? collateralCurrency = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("adjustId", adjustId),
-                ("collateralCurrency", collateralCurrency),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_COLLATERAL_ADJUSTMENT_HISTORY, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("adjustId", adjustId), ("collateralCurrency", collateralCurrency), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetCollateralAdjustmentHistoryResult>>(GET_COLLATERAL_ADJUSTMENT_HISTORY, HttpMethod.Get, query: query);
         }
 
-        private const string GET_CRYPTO_LOAN_POSITION = "/v5/crypto-loan-common/position";
-
-        /// <summary>
-        /// Get Crypto Loan Position
-        /// Spot trade permission required. Returns borrow, collateral, and supply positions.
-        /// </summary>
-        /// <returns></returns>
-        public async Task<string?> GetCryptoLoanPosition()
+        public async Task<GeneralResponse<GetCryptoLoanPositionResult>?> GetCryptoLoanPosition()
         {
-            var result = await this.SendSignedAsync<string>(GET_CRYPTO_LOAN_POSITION, HttpMethod.Get);
-            return result;
+            return await SendSignedAsync<GeneralResponse<GetCryptoLoanPositionResult>>(GET_CRYPTO_LOAN_POSITION, HttpMethod.Get);
         }
 
-        private const string BORROW_FLEXIBLE_LOAN = "/v5/crypto-loan-flexible/borrow";
-
-        /// <summary>
-        /// Flexible Borrow
-        /// Borrow with optional collateral list. Funds move to/from Funding wallet.
-        /// </summary>
-        /// <param name="loanCurrency">Loan coin</param>
-        /// <param name="loanAmount">Amount to borrow</param>
-        /// <param name="collateralList">
-        /// Optional list of (collateralCurrency, collateralAmount). Up to 100 items.
-        /// </param>
-        /// <returns></returns>
-        public async Task<string?> BorrowFlexibleLoan(
-            string loanCurrency,
-            string loanAmount,
-            IEnumerable<(string collateralCurrency, string collateralAmount)>? collateralList = null)
+        public async Task<GeneralResponse<CryptoLoanOrderIdResult>?> BorrowFlexibleLoan(string loanCurrency, string loanAmount, List<CryptoLoanCollateralItem>? collateralList = null)
         {
             var body = new Dictionary<string, object>
             {
                 { "loanCurrency", loanCurrency },
                 { "loanAmount", loanAmount }
             };
-
-            if (collateralList != null)
-            {
-                body["collateralList"] = collateralList
-                    .Select(c => new Dictionary<string, object>
-                    {
-                { "collateralCurrency", c.collateralCurrency },
-                { "collateralAmount", c.collateralAmount }
-                    })
-                    .ToList();
-            }
-
-            var result = await this.SendSignedAsync<string>(BORROW_FLEXIBLE_LOAN, HttpMethod.Post, query: body);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(body, ("collateralList", collateralList));
+            return await SendSignedAsync<GeneralResponse<CryptoLoanOrderIdResult>>(BORROW_FLEXIBLE_LOAN, HttpMethod.Post, query: body);
         }
 
-        private const string REPAY_FLEXIBLE_LOAN = "/v5/crypto-loan-flexible/repay";
-
-        /// <summary>
-        /// Flexible Repay
-        /// Fully or partially repay a flexible loan. Funds are deducted from Funding wallet.
-        /// </summary>
-        /// <param name="loanCurrency">Loan currency</param>
-        /// <param name="amount">Repay amount</param>
-        /// <returns></returns>
-        public async Task<string?> RepayFlexibleLoan(string loanCurrency, string amount)
+        public async Task<GeneralResponse<CryptoLoanRepayIdResult>?> RepayFlexibleLoan(string loanCurrency, string amount)
         {
-            var body = new Dictionary<string, object>
-            {
-                { "loanCurrency", loanCurrency },
-                { "amount", amount }
-            };
-
-            var result = await this.SendSignedAsync<string>(REPAY_FLEXIBLE_LOAN, HttpMethod.Post, query: body);
-            return result;
+            var body = new Dictionary<string, object> { { "loanCurrency", loanCurrency }, { "amount", amount } };
+            return await SendSignedAsync<GeneralResponse<CryptoLoanRepayIdResult>>(REPAY_FLEXIBLE_LOAN, HttpMethod.Post, query: body);
         }
 
-        private const string REPAY_COLLATERAL_FLEXIBLE = "/v5/crypto-loan-flexible/repay-collateral";
-
-        /// <summary>
-        /// Flexible Collateral Repayment
-        /// Pay interest first, then principal. Spot trade permission required.
-        /// </summary>
-        /// <param name="loanCurrency">Loan currency</param>
-        /// <param name="collateralCoin">Collateral currencies, comma-separated for multiple</param>
-        /// <param name="amount">Repay amount</param>
-        /// <returns></returns>
-        public async Task<string?> RepayCollateralFlexible(string loanCurrency, string collateralCoin, string amount)
+        public async Task<GeneralResponse<object>?> RepayCollateralFlexible(string loanCurrency, string collateralCoin, string amount)
         {
             var body = new Dictionary<string, object>
             {
@@ -220,176 +132,45 @@ namespace bybit.net.api.ApiServiceImp
                 { "collateralCoin", collateralCoin },
                 { "amount", amount }
             };
-
-            var result = await this.SendSignedAsync<string>(REPAY_COLLATERAL_FLEXIBLE, HttpMethod.Post, query: body);
-            return result;
+            return await SendSignedAsync<GeneralResponse<object>>(REPAY_COLLATERAL_FLEXIBLE, HttpMethod.Post, query: body);
         }
 
-        private const string GET_FLEXIBLE_LOANS = "/v5/crypto-loan-flexible/ongoing-coin";
-
-        /// <summary>
-        /// Flexible: Get Flexible loans
-        /// Query ongoing flexible loans.
-        /// </summary>
-        /// <param name="loanCurrency">Optional loan coin</param>
-        /// <returns></returns>
-        public async Task<string?> GetFlexibleLoans(string? loanCurrency = null)
+        public async Task<GeneralResponse<GetFlexibleLoansResult>?> GetFlexibleLoans(string? loanCurrency = null)
         {
             var query = new Dictionary<string, object>();
             BybitParametersUtils.AddOptionalParameters(query, ("loanCurrency", loanCurrency));
-
-            var result = await this.SendSignedAsync<string>(GET_FLEXIBLE_LOANS, HttpMethod.Get, query: query);
-            return result;
+            return await SendSignedAsync<GeneralResponse<GetFlexibleLoansResult>>(GET_FLEXIBLE_LOANS, HttpMethod.Get, query: query);
         }
 
-        private const string GET_FLEXIBLE_BORROW_ORDERS_HISTORY = "/v5/crypto-loan-flexible/borrow-history";
-
-        /// <summary>
-        /// Flexible: Get Borrow Orders History
-        /// </summary>
-        /// <param name="orderId">Loan order ID</param>
-        /// <param name="loanCurrency">Loan coin</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetFlexibleBorrowOrdersHistory(
-            string? orderId = null,
-            string? loanCurrency = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetFlexibleBorrowOrdersHistoryResult>?> GetFlexibleBorrowOrdersHistory(string? orderId = null, string? loanCurrency = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("orderId", orderId),
-                ("loanCurrency", loanCurrency),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_FLEXIBLE_BORROW_ORDERS_HISTORY, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("loanCurrency", loanCurrency), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetFlexibleBorrowOrdersHistoryResult>>(GET_FLEXIBLE_BORROW_ORDERS_HISTORY, HttpMethod.Get, query: query);
         }
 
-        private const string GET_FLEXIBLE_REPAYMENT_ORDERS_HISTORY = "/v5/crypto-loan-flexible/repayment-history";
-
-        /// <summary>
-        /// Flexible: Get Repayment Orders History
-        /// </summary>
-        /// <param name="repayId">Repayment transaction ID</param>
-        /// <param name="loanCurrency">Loan coin</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetFlexibleRepaymentOrdersHistory(
-            string? repayId = null,
-            string? loanCurrency = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetFlexibleRepaymentOrdersHistoryResult>?> GetFlexibleRepaymentOrdersHistory(string? repayId = null, string? loanCurrency = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("repayId", repayId),
-                ("loanCurrency", loanCurrency),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_FLEXIBLE_REPAYMENT_ORDERS_HISTORY, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("repayId", repayId), ("loanCurrency", loanCurrency), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetFlexibleRepaymentOrdersHistoryResult>>(GET_FLEXIBLE_REPAYMENT_ORDERS_HISTORY, HttpMethod.Get, query: query);
         }
 
-        private const string GET_SUPPLYING_MARKET_FIXED = "/v5/crypto-loan-fixed/supply-order-quote";
-
-        /// <summary>
-        /// Fixed: Get Supplying Market
-        /// Public. Check available counterparty borrow orders for supplying.
-        /// </summary>
-        /// <param name="orderCurrency">Coin name</param>
-        /// <param name="orderBy">apy | term | quantity</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="sort">0 asc (default), 1 desc</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <returns></returns>
-        public async Task<string?> GetSupplyingMarketFixed(
-            string orderCurrency,
-            string orderBy,
-            int? term = null,
-            int? sort = null,
-            int? limit = null)
+        public async Task<GeneralResponse<GetFixedLoanMarketResult>?> GetSupplyingMarketFixed(string orderCurrency, string orderBy, string? term = null, int? sort = null, int? limit = null)
         {
-            var query = new Dictionary<string, object>
-            {
-                { "orderCurrency", orderCurrency },
-                { "orderBy", orderBy }
-            };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("term", term),
-                ("sort", sort),
-                ("limit", limit)
-            );
-
-            var result = await this.SendPublicAsync<string>(GET_SUPPLYING_MARKET_FIXED, HttpMethod.Get, query: query);
-            return result;
+            var query = new Dictionary<string, object> { { "orderCurrency", orderCurrency }, { "orderBy", orderBy } };
+            BybitParametersUtils.AddOptionalParameters(query, ("term", term), ("sort", sort), ("limit", limit));
+            return await SendPublicAsync<GeneralResponse<GetFixedLoanMarketResult>>(GET_SUPPLYING_MARKET_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string GET_BORROWING_MARKET_FIXED = "/v5/crypto-loan-fixed/borrow-order-quote";
-
-        /// <summary>
-        /// Fixed: Get Borrowing Market
-        /// Public. Check available counterparty supply orders for borrowing.
-        /// </summary>
-        /// <param name="orderCurrency">Coin name</param>
-        /// <param name="orderBy">apy | term | quantity</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="sort">0 asc (default), 1 desc</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <returns></returns>
-        public async Task<string?> GetBorrowingMarketFixed(
-            string orderCurrency,
-            string orderBy,
-            int? term = null,
-            int? sort = null,
-            int? limit = null)
+        public async Task<GeneralResponse<GetFixedLoanMarketResult>?> GetBorrowingMarketFixed(string orderCurrency, string orderBy, string? term = null, int? sort = null, int? limit = null)
         {
-            var query = new Dictionary<string, object>
-            {
-                { "orderCurrency", orderCurrency },
-                { "orderBy", orderBy }
-            };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("term", term),
-                ("sort", sort),
-                ("limit", limit)
-            );
-
-            var result = await this.SendPublicAsync<string>(GET_BORROWING_MARKET_FIXED, HttpMethod.Get, query: query);
-            return result;
+            var query = new Dictionary<string, object> { { "orderCurrency", orderCurrency }, { "orderBy", orderBy } };
+            BybitParametersUtils.AddOptionalParameters(query, ("term", term), ("sort", sort), ("limit", limit));
+            return await SendPublicAsync<GeneralResponse<GetFixedLoanMarketResult>>(GET_BORROWING_MARKET_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string CREATE_BORROW_ORDER_FIXED = "/v5/crypto-loan-fixed/borrow";
-
-        /// <summary>
-        /// Fixed: Create Borrow Order
-        /// Create a fixed-term borrow order. Funds move to/from Funding wallet.
-        /// </summary>
-        /// <param name="orderCurrency">Currency to borrow</param>
-        /// <param name="orderAmount">Amount to borrow</param>
-        /// <param name="annualRate">Annual interest rate, e.g., "0.02"</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180 (days)</param>
-        /// <param name="autoRepay">"true" to enable, "false" to disable</param>
-        /// <param name="collateralList">Optional list of (currency, amount), up to 100</param>
-        /// <returns></returns>
-        public async Task<string?> CreateBorrowOrderFixed(
-            string orderCurrency,
-            string orderAmount,
-            string annualRate,
-            string term,
-            string? autoRepay = null,
-            IEnumerable<(string currency, string amount)>? collateralList = null)
+        public async Task<GeneralResponse<CryptoLoanOrderIdResult>?> CreateBorrowOrderFixed(string orderCurrency, string orderAmount, string annualRate, string term, string? autoRepay = null, string? repayType = null, List<CryptoLoanCollateralItem>? collateralList = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -398,39 +179,11 @@ namespace bybit.net.api.ApiServiceImp
                 { "annualRate", annualRate },
                 { "term", term }
             };
-
-            BybitParametersUtils.AddOptionalParameters(body, ("autoRepay", autoRepay));
-
-            if (collateralList != null)
-            {
-                body["collateralList"] = collateralList
-                    .Select(x => new Dictionary<string, object>
-                    {
-                { "currency", x.currency },
-                { "amount", x.amount }
-                    }).ToList();
-            }
-
-            var result = await this.SendSignedAsync<string>(CREATE_BORROW_ORDER_FIXED, HttpMethod.Post, query: body);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(body, ("autoRepay", autoRepay), ("repayType", repayType), ("collateralList", collateralList));
+            return await SendSignedAsync<GeneralResponse<CryptoLoanOrderIdResult>>(CREATE_BORROW_ORDER_FIXED, HttpMethod.Post, query: body);
         }
 
-        private const string CREATE_SUPPLY_ORDER_FIXED = "/v5/crypto-loan-fixed/supply";
-
-        /// <summary>
-        /// Fixed: Create Supply Order
-        /// Create a fixed-term supply order.
-        /// </summary>
-        /// <param name="orderCurrency">Currency to supply</param>
-        /// <param name="orderAmount">Amount to supply</param>
-        /// <param name="annualRate">Annual interest rate, e.g., "0.02"</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180 (days)</param>
-        /// <returns></returns>
-        public async Task<string?> CreateSupplyOrderFixed(
-            string orderCurrency,
-            string orderAmount,
-            string annualRate,
-            string term)
+        public async Task<GeneralResponse<CryptoLoanOrderIdResult>?> CreateSupplyOrderFixed(string orderCurrency, string orderAmount, string annualRate, string term)
         {
             var body = new Dictionary<string, object>
             {
@@ -439,226 +192,57 @@ namespace bybit.net.api.ApiServiceImp
                 { "annualRate", annualRate },
                 { "term", term }
             };
-
-            var result = await this.SendSignedAsync<string>(CREATE_SUPPLY_ORDER_FIXED, HttpMethod.Post, query: body);
-            return result;
+            return await SendSignedAsync<GeneralResponse<CryptoLoanOrderIdResult>>(CREATE_SUPPLY_ORDER_FIXED, HttpMethod.Post, query: body);
         }
 
-        private const string CANCEL_BORROW_ORDER_FIXED = "/v5/crypto-loan-fixed/borrow-order-cancel";
-
-        /// <summary>
-        /// Fixed: Cancel Borrow Order
-        /// Cancel a fixed borrow order.
-        /// </summary>
-        /// <param name="orderId">Fixed borrow order ID</param>
-        /// <returns></returns>
-        public async Task<string?> CancelBorrowOrderFixed(string orderId)
+        public async Task<GeneralResponse<object>?> CancelBorrowOrderFixed(string orderId)
         {
-            var body = new Dictionary<string, object>
-            {
-                { "orderId", orderId }
-            };
-
-            var result = await this.SendSignedAsync<string>(CANCEL_BORROW_ORDER_FIXED, HttpMethod.Post, query: body);
-            return result;
+            var body = new Dictionary<string, object> { { "orderId", orderId } };
+            return await SendSignedAsync<GeneralResponse<object>>(CANCEL_BORROW_ORDER_FIXED, HttpMethod.Post, query: body);
         }
 
-        private const string CANCEL_SUPPLY_ORDER_FIXED = "/v5/crypto-loan-fixed/supply-order-cancel";
-
-        /// <summary>
-        /// Fixed: Cancel Supply Order
-        /// Cancel a fixed supply order.
-        /// </summary>
-        /// <param name="orderId">Fixed supply order ID</param>
-        /// <returns></returns>
-        public async Task<string?> CancelSupplyOrderFixed(string orderId)
+        public async Task<GeneralResponse<object>?> CancelSupplyOrderFixed(string orderId)
         {
-            var body = new Dictionary<string, object>
-            {
-                { "orderId", orderId }
-            };
-
-            var result = await this.SendSignedAsync<string>(CANCEL_SUPPLY_ORDER_FIXED, HttpMethod.Post, query: body);
-            return result;
+            var body = new Dictionary<string, object> { { "orderId", orderId } };
+            return await SendSignedAsync<GeneralResponse<object>>(CANCEL_SUPPLY_ORDER_FIXED, HttpMethod.Post, query: body);
         }
 
-        private const string GET_BORROW_CONTRACT_INFO_FIXED = "/v5/crypto-loan-fixed/borrow-contract-info";
-
-        /// <summary>
-        /// Fixed: Get Borrow Contract Info
-        /// Spot trade permission required. Returns fixed-term borrow contracts.
-        /// </summary>
-        /// <param name="orderId">Loan order ID</param>
-        /// <param name="loanId">Loan ID</param>
-        /// <param name="orderCurrency">Loan coin</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetBorrowContractInfoFixed(
-            string? orderId = null,
-            string? loanId = null,
-            string? orderCurrency = null,
-            string? term = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetBorrowContractInfoFixedResult>?> GetBorrowContractInfoFixed(string? orderId = null, string? loanId = null, string? orderCurrency = null, string? term = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("orderId", orderId),
-                ("loanId", loanId),
-                ("orderCurrency", orderCurrency),
-                ("term", term),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_BORROW_CONTRACT_INFO_FIXED, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("loanId", loanId), ("orderCurrency", orderCurrency), ("term", term), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetBorrowContractInfoFixedResult>>(GET_BORROW_CONTRACT_INFO_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string GET_SUPPLY_CONTRACT_INFO_FIXED = "/v5/crypto-loan-fixed/supply-contract-info";
-
-        /// <summary>
-        /// Fixed: Get Supply Contract Info
-        /// Spot trade permission required. Returns fixed-term supply contracts.
-        /// </summary>
-        /// <param name="orderId">Supply order ID</param>
-        /// <param name="supplyId">Supply contract ID</param>
-        /// <param name="supplyCurrency">Supply coin</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetSupplyContractInfoFixed(
-            string? orderId = null,
-            string? supplyId = null,
-            string? supplyCurrency = null,
-            string? term = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetSupplyContractInfoFixedResult>?> GetSupplyContractInfoFixed(string? orderId = null, string? supplyId = null, string? supplyCurrency = null, string? term = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("orderId", orderId),
-                ("supplyId", supplyId),
-                ("supplyCurrency", supplyCurrency),
-                ("term", term),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_SUPPLY_CONTRACT_INFO_FIXED, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("supplyId", supplyId), ("supplyCurrency", supplyCurrency), ("term", term), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetSupplyContractInfoFixedResult>>(GET_SUPPLY_CONTRACT_INFO_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string GET_BORROW_ORDER_INFO_FIXED = "/v5/crypto-loan-fixed/borrow-order-info";
-
-        /// <summary>
-        /// Fixed: Get Borrow Order Info
-        /// Spot trade permission required. Query fixed borrow orders.
-        /// </summary>
-        /// <param name="orderId">Loan order ID</param>
-        /// <param name="orderCurrency">Loan coin</param>
-        /// <param name="state">1 matching; 2 partially filled and cancelled; 3 fully filled; 4 cancelled</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetBorrowOrderInfoFixed(
-            string? orderId = null,
-            string? orderCurrency = null,
-            string? state = null,
-            string? term = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetBorrowOrderInfoFixedResult>?> GetBorrowOrderInfoFixed(string? orderId = null, string? orderCurrency = null, string? state = null, string? term = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("orderId", orderId),
-                ("orderCurrency", orderCurrency),
-                ("state", state),
-                ("term", term),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_BORROW_ORDER_INFO_FIXED, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("orderCurrency", orderCurrency), ("state", state), ("term", term), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetBorrowOrderInfoFixedResult>>(GET_BORROW_ORDER_INFO_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string GET_SUPPLY_ORDER_INFO_FIXED = "/v5/crypto-loan-fixed/supply-order-info";
-
-        /// <summary>
-        /// Fixed: Get Supply Order Info
-        /// Spot trade permission required. Query fixed supply orders.
-        /// </summary>
-        /// <param name="orderId">Supply order ID</param>
-        /// <param name="orderCurrency">Supply coin</param>
-        /// <param name="state">1 matching; 2 partially filled and cancelled; 3 fully filled; 4 cancelled</param>
-        /// <param name="term">7 | 14 | 30 | 90 | 180</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetSupplyOrderInfoFixed(
-            string? orderId = null,
-            string? orderCurrency = null,
-            string? state = null,
-            string? term = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetSupplyOrderInfoFixedResult>?> GetSupplyOrderInfoFixed(string? orderId = null, string? orderCurrency = null, string? state = null, string? term = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("orderId", orderId),
-                ("orderCurrency", orderCurrency),
-                ("state", state),
-                ("term", term),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
-
-            var result = await this.SendSignedAsync<string>(GET_SUPPLY_ORDER_INFO_FIXED, HttpMethod.Get, query: query);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("orderCurrency", orderCurrency), ("state", state), ("term", term), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetSupplyOrderInfoFixedResult>>(GET_SUPPLY_ORDER_INFO_FIXED, HttpMethod.Get, query: query);
         }
 
-        private const string REPAY_FIXED_LOAN = "/v5/crypto-loan-fixed/fully-repay";
-
-        /// <summary>
-        /// Fixed: Repay
-        /// Fully repay a fixed loan. Pass either loanId or loanCurrency.
-        /// </summary>
-        /// <param name="loanId">Loan contract ID</param>
-        /// <param name="loanCurrency">Loan coin</param>
-        /// <returns></returns>
-        public async Task<string?> RepayFixedLoan(string? loanId = null, string? loanCurrency = null)
+        public async Task<GeneralResponse<CryptoLoanRepayIdResult>?> RepayFixedLoan(string? loanId = null, string? loanCurrency = null)
         {
             var body = new Dictionary<string, object>();
-            BybitParametersUtils.AddOptionalParameters(body,
-                ("loanId", loanId),
-                ("loanCurrency", loanCurrency)
-            );
-
-            var result = await this.SendSignedAsync<string>(REPAY_FIXED_LOAN, HttpMethod.Post, query: body);
-            return result;
+            BybitParametersUtils.AddOptionalParameters(body, ("loanId", loanId), ("loanCurrency", loanCurrency));
+            return await SendSignedAsync<GeneralResponse<CryptoLoanRepayIdResult>>(REPAY_FIXED_LOAN, HttpMethod.Post, query: body);
         }
 
-        private const string REPAY_COLLATERAL_FIXED = "/v5/crypto-loan-fixed/repay-collateral";
-
-        /// <summary>
-        /// Fixed: Collateral Repayment
-        /// Pays interest first, then principal. If <paramref name="loanId"/> is null, fixed-currency offset logic applies.
-        /// </summary>
-        /// <param name="loanCurrency">Loan currency</param>
-        /// <param name="collateralCoin">Collateral currencies, comma-separated</param>
-        /// <param name="amount">Repay amount</param>
-        /// <param name="loanId">Loan contract ID (optional)</param>
-        /// <returns></returns>
-        public async Task<string?> RepayCollateralFixed(string loanCurrency, string collateralCoin, string amount, string? loanId = null)
+        public async Task<GeneralResponse<object>?> RepayCollateralFixed(string loanCurrency, string collateralCoin, string amount, string? loanId = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -667,39 +251,28 @@ namespace bybit.net.api.ApiServiceImp
                 { "amount", amount }
             };
             BybitParametersUtils.AddOptionalParameters(body, ("loanId", loanId));
-
-            var result = await this.SendSignedAsync<string>(REPAY_COLLATERAL_FIXED, HttpMethod.Post, query: body);
-            return result;
+            return await SendSignedAsync<GeneralResponse<object>>(REPAY_COLLATERAL_FIXED, HttpMethod.Post, query: body);
         }
 
-        private const string GET_REPAYMENT_HISTORY_FIXED = "/v5/crypto-loan-fixed/repayment-history";
-
-        /// <summary>
-        /// Fixed: Get Repayment History
-        /// Spot trade permission required. Paginated.
-        /// </summary>
-        /// <param name="repayId">Repayment order ID</param>
-        /// <param name="loanCurrency">Loan coin name</param>
-        /// <param name="limit">[1,100], default 10</param>
-        /// <param name="cursor">pagination cursor</param>
-        /// <returns></returns>
-        public async Task<string?> GetRepaymentHistoryFixed(
-            string? repayId = null,
-            string? loanCurrency = null,
-            string? limit = null,
-            string? cursor = null)
+        public async Task<GeneralResponse<GetRepaymentHistoryFixedResult>?> GetRepaymentHistoryFixed(string? repayId = null, string? loanCurrency = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query, ("repayId", repayId), ("loanCurrency", loanCurrency), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetRepaymentHistoryFixedResult>>(GET_REPAYMENT_HISTORY_FIXED, HttpMethod.Get, query: query);
+        }
 
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("repayId", repayId),
-                ("loanCurrency", loanCurrency),
-                ("limit", limit),
-                ("cursor", cursor)
-            );
+        public async Task<GeneralResponse<CryptoLoanOrderIdResult>?> RenewFixedLoan(string loanId, List<CryptoLoanCollateralItem>? collateralList = null)
+        {
+            var body = new Dictionary<string, object> { { "loanId", loanId } };
+            BybitParametersUtils.AddOptionalParameters(body, ("collateralList", collateralList));
+            return await SendSignedAsync<GeneralResponse<CryptoLoanOrderIdResult>>(RENEW_FIXED_LOAN, HttpMethod.Post, query: body);
+        }
 
-            var result = await this.SendSignedAsync<string>(GET_REPAYMENT_HISTORY_FIXED, HttpMethod.Get, query: query);
-            return result;
+        public async Task<GeneralResponse<GetRenewOrderInfoFixedResult>?> GetRenewOrderInfoFixed(string? orderId = null, string? orderCurrency = null, string? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query, ("orderId", orderId), ("orderCurrency", orderCurrency), ("limit", limit), ("cursor", cursor));
+            return await SendSignedAsync<GeneralResponse<GetRenewOrderInfoFixedResult>>(GET_RENEW_ORDER_INFO_FIXED, HttpMethod.Get, query: query);
         }
     }
 }

--- a/Src/Common/ApiServiceImp/BybitP2PService.cs
+++ b/Src/Common/ApiServiceImp/BybitP2PService.cs
@@ -1,4 +1,6 @@
 ﻿using bybit.net.api.Services;
+using bybit.net.api.Models;
+using bybit.net.api.Models.P2P;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +33,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="page">Page number, default 1</param>
         /// <param name="size">Page size, default 10</param>
         /// <returns></returns>
-        public async Task<string?> GetAds(string tokenId, string currencyId, string side, string? page = null, string? size = null)
+        public async Task<P2PResponse<GetAdsResult>?> GetAds(string tokenId, string currencyId, string side, string? page = null, string? size = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -45,7 +47,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("size", size)
             );
 
-            var result = await this.SendPublicAsync<string>(GET_P2P_ADS, HttpMethod.Post, query: body);
+            var result = await this.SendPublicAsync<P2PResponse<GetAdsResult>>(GET_P2P_ADS, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -75,7 +77,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="paymentPeriod">Payment period in minutes</param>
         /// <param name="itemType">"ORIGIN" or "BULK"</param>
         /// <returns></returns>
-        public async Task<string?> PostAd(
+        public async Task<P2PResponse<PostAdResult>?> PostAd(
             string tokenId,
             string currencyId,
             string side,
@@ -109,7 +111,7 @@ namespace bybit.net.api.ApiServiceImp
                 { "itemType", itemType }
             };
 
-            var result = await this.SendSignedAsync<string>(POST_P2P_AD, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<PostAdResult>>(POST_P2P_AD, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -121,14 +123,14 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="itemId">Advertisement ID</param>
         /// <returns></returns>
-        public async Task<string?> RemoveAd(string itemId)
+        public async Task<P2PResponse<object>?> RemoveAd(string itemId)
         {
             var body = new Dictionary<string, object>
             {
                 { "itemId", itemId }
             };
 
-            var result = await this.SendSignedAsync<string>(REMOVE_P2P_AD, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<object>>(REMOVE_P2P_AD, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -156,7 +158,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="quantity">Token quantity</param>
         /// <param name="paymentPeriod">Payment period in minutes</param>
         /// <returns></returns>
-        public async Task<string?> UpdateOrRelistAd(
+        public async Task<P2PResponse<object>?> UpdateOrRelistAd(
             string id,
             string priceType,
             string premium,
@@ -186,7 +188,7 @@ namespace bybit.net.api.ApiServiceImp
                 { "paymentPeriod", paymentPeriod }
             };
 
-            var result = await this.SendSignedAsync<string>(UPDATE_RELIST_P2P_AD, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<object>>(UPDATE_RELIST_P2P_AD, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -205,7 +207,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="size">default 10</param>
         /// <param name="currencyId">e.g., USD</param>
         /// <returns></returns>
-        public async Task<string?> GetMyAds(
+        public async Task<P2PResponse<GetMyAdsResult>?> GetMyAds(
             string? itemId = null,
             string? status = null,
             string? side = null,
@@ -226,7 +228,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("currencyId", currencyId)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_MY_P2P_ADS, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetMyAdsResult>>(GET_MY_P2P_ADS, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -239,14 +241,14 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="itemId">Advertisement ID</param>
         /// <returns></returns>
-        public async Task<string?> GetMyAdDetails(string itemId)
+        public async Task<P2PResponse<MyAdItem>?> GetMyAdDetails(string itemId)
         {
             var body = new Dictionary<string, object>
             {
                 { "itemId", itemId }
             };
 
-            var result = await this.SendSignedAsync<string>(GET_MY_AD_DETAILS, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<MyAdItem>>(GET_MY_AD_DETAILS, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -262,16 +264,16 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="beginTime">Begin time</param>
         /// <param name="endTime">End time</param>
         /// <param name="tokenId">Token id</param>
-        /// <param name="side">Sides filter, e.g., [0] or [1,0]</param>
+        /// <param name="side">Side filter. 0 buy; 1 sell</param>
         /// <returns></returns>
-        public async Task<string?> GetAllOrders(
+        public async Task<P2PResponse<GetAllOrdersResult>?> GetAllOrders(
             int page,
             int size,
             int? status = null,
             string? beginTime = null,
             string? endTime = null,
             string? tokenId = null,
-            IEnumerable<int>? side = null)
+            int? side = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -284,10 +286,10 @@ namespace bybit.net.api.ApiServiceImp
                 ("beginTime", beginTime),
                 ("endTime", endTime),
                 ("tokenId", tokenId),
-                ("side", side?.ToArray())
+                ("side", side)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_P2P_ALL_ORDERS, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetAllOrdersResult>>(GET_P2P_ALL_ORDERS, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -299,14 +301,14 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="orderId">Order ID</param>
         /// <returns></returns>
-        public async Task<string?> GetOrderDetail(string orderId)
+        public async Task<P2PResponse<GetOrderDetailResult>?> GetOrderDetail(string orderId)
         {
             var body = new Dictionary<string, object>
             {
                 { "orderId", orderId }
             };
 
-            var result = await this.SendSignedAsync<string>(GET_P2P_ORDER_DETAIL, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetOrderDetailResult>>(GET_P2P_ORDER_DETAIL, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -322,16 +324,16 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="beginTime">Begin time</param>
         /// <param name="endTime">End time</param>
         /// <param name="tokenId">Token id</param>
-        /// <param name="side">Sides filter, e.g., [0] or [0,1]</param>
+        /// <param name="side">Side filter. 0 buy; 1 sell</param>
         /// <returns></returns>
-        public async Task<string?> GetPendingOrders(
+        public async Task<P2PResponse<GetAllOrdersResult>?> GetPendingOrders(
             int page,
             int size,
             int? status = null,
             string? beginTime = null,
             string? endTime = null,
             string? tokenId = null,
-            IEnumerable<int>? side = null)
+            int? side = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -344,10 +346,10 @@ namespace bybit.net.api.ApiServiceImp
                 ("beginTime", beginTime),
                 ("endTime", endTime),
                 ("tokenId", tokenId),
-                ("side", side?.ToArray())
+                ("side", side)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_P2P_PENDING_ORDERS, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetAllOrdersResult>>(GET_P2P_PENDING_ORDERS, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -362,7 +364,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="paymentType">Payment method type</param>
         /// <param name="paymentId">Payment method ID</param>
         /// <returns></returns>
-        public async Task<string?> MarkOrderAsPaid(string orderId, string paymentType, string paymentId)
+        public async Task<P2PResponse<object>?> MarkOrderAsPaid(string orderId, string paymentType, string paymentId)
         {
             var body = new Dictionary<string, object>
             {
@@ -371,7 +373,7 @@ namespace bybit.net.api.ApiServiceImp
                 { "paymentId", paymentId }
             };
 
-            var result = await this.SendSignedAsync<string>(MARK_P2P_ORDER_AS_PAID, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<object>>(MARK_P2P_ORDER_AS_PAID, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -384,14 +386,49 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="orderId">Order ID</param>
         /// <returns></returns>
-        public async Task<string?> ReleaseAssets(string orderId)
+        public async Task<P2PResponse<object>?> ReleaseAssets(string orderId)
         {
             var body = new Dictionary<string, object>
             {
                 { "orderId", orderId }
             };
 
-            var result = await this.SendSignedAsync<string>(RELEASE_P2P_ORDER_ASSETS, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<object>>(RELEASE_P2P_ORDER_ASSETS, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        private const string REVIEW_SELLER_CANCEL_ORDER_APPLY = "/v5/p2p/order/buyer/examine/sellerCancelOrderApply";
+
+        /// <summary>
+        /// Review Seller Cancel Order Apply
+        /// Approve or reject a seller cancel request as the buyer.
+        /// </summary>
+        /// <param name="orderId">Order ID</param>
+        /// <param name="examineResult">PASS or REJECT</param>
+        /// <param name="rejectReason">Reject reason. Required when examineResult is REJECT</param>
+        /// <param name="rejectProofs">Reject proof image URLs or identifiers, comma-separated. Required when examineResult is REJECT</param>
+        /// <param name="rejectRemark">Reject remark</param>
+        /// <returns></returns>
+        public async Task<GeneralResponse<object>?> ReviewSellerCancelOrderApply(
+            string orderId,
+            string examineResult,
+            string? rejectReason = null,
+            string? rejectProofs = null,
+            string? rejectRemark = null)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "orderId", orderId },
+                { "examineResult", examineResult }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(body,
+                ("rejectReason", rejectReason),
+                ("rejectProofs", rejectProofs),
+                ("rejectRemark", rejectRemark)
+            );
+
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(REVIEW_SELLER_CANCEL_ORDER_APPLY, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -408,7 +445,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="msgUuid">Client message UUID</param>
         /// <param name="fileName">Optional filename for pic/pdf/video</param>
         /// <returns></returns>
-        public async Task<string?> SendChatMessage(
+        public async Task<P2PResponse<object>?> SendChatMessage(
             string message,
             string contentType,
             string orderId,
@@ -425,7 +462,28 @@ namespace bybit.net.api.ApiServiceImp
 
             BybitParametersUtils.AddOptionalParameters(body, ("fileName", fileName));
 
-            var result = await this.SendSignedAsync<string>(SEND_P2P_CHAT_MESSAGE, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<object>>(SEND_P2P_CHAT_MESSAGE, HttpMethod.Post, query: body);
+            return result;
+        }
+
+        private const string UPLOAD_P2P_CHAT_FILE = "/v5/p2p/oss/upload_file";
+
+        /// <summary>
+        /// Upload Chat File
+        /// Upload a file for P2P order chat.
+        /// </summary>
+        /// <param name="fileContent">File content stream</param>
+        /// <param name="fileName">File name</param>
+        /// <param name="contentType">File content type</param>
+        /// <returns></returns>
+        public async Task<P2PResponse<UploadChatFileResult>?> UploadChatFile(Stream fileContent, string fileName, string contentType)
+        {
+            using var content = new MultipartFormDataContent();
+            var file = new StreamContent(fileContent);
+            file.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+            content.Add(file, "upload_file", fileName);
+
+            var result = await this.SendSignedMultipartAsync<P2PResponse<UploadChatFileResult>>(UPLOAD_P2P_CHAT_FILE, content);
             return result;
         }
 
@@ -439,7 +497,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="size">Page size</param>
         /// <param name="currentPage">Current page number</param>
         /// <returns></returns>
-        public async Task<string?> GetChatMessage(string orderId, string size, string? currentPage = null)
+        public async Task<P2PResponse<GetChatMessageResult>?> GetChatMessage(string orderId, string size, string? currentPage = null)
         {
             var body = new Dictionary<string, object>
             {
@@ -448,7 +506,7 @@ namespace bybit.net.api.ApiServiceImp
             };
             BybitParametersUtils.AddOptionalParameters(body, ("currentPage", currentPage));
 
-            var result = await this.SendSignedAsync<string>(GET_P2P_CHAT_MESSAGE, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetChatMessageResult>>(GET_P2P_CHAT_MESSAGE, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -459,10 +517,10 @@ namespace bybit.net.api.ApiServiceImp
         /// Returns your P2P account profile. POST uses query: body with no parameters.
         /// </summary>
         /// <returns></returns>
-        public async Task<string?> GetAccountInformation()
+        public async Task<P2PResponse<GetAccountInformationResult>?> GetAccountInformation()
         {
             var body = new Dictionary<string, object>(); // empty POST payload goes in query
-            var result = await this.SendSignedAsync<string>(GET_P2P_ACCOUNT_INFORMATION, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetAccountInformationResult>>(GET_P2P_ACCOUNT_INFORMATION, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -476,7 +534,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="originalUid">Counterparty User ID</param>
         /// <param name="orderId">Order ID</param>
         /// <returns></returns>
-        public async Task<string?> GetCounterpartyUserInfo(string? originalUid = null, string? orderId = null)
+        public async Task<P2PResponse<GetAccountInformationResult>?> GetCounterpartyUserInfo(string? originalUid = null, string? orderId = null)
         {
             var body = new Dictionary<string, object>();
             BybitParametersUtils.AddOptionalParameters(body,
@@ -484,7 +542,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("orderId", orderId)
             );
 
-            var result = await this.SendSignedAsync<string>(GET_P2P_COUNTERPARTY_USER_INFO, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<GetAccountInformationResult>>(GET_P2P_COUNTERPARTY_USER_INFO, HttpMethod.Post, query: body);
             return result;
         }
 
@@ -494,10 +552,10 @@ namespace bybit.net.api.ApiServiceImp
         /// Get User Payment
         /// Returns your saved P2P payment methods. POST sends params via query: body (none here).
         /// </summary>
-        public async Task<string?> GetUserPayment()
+        public async Task<P2PResponse<List<UserPaymentItem>>?> GetUserPayment()
         {
             var body = new Dictionary<string, object>(); // empty payload
-            var result = await this.SendSignedAsync<string>(GET_P2P_USER_PAYMENT, HttpMethod.Post, query: body);
+            var result = await this.SendSignedAsync<P2PResponse<List<UserPaymentItem>>>(GET_P2P_USER_PAYMENT, HttpMethod.Post, query: body);
             return result;
         }
     }

--- a/Src/Common/ApiServiceImp/BybitPositionService.cs
+++ b/Src/Common/ApiServiceImp/BybitPositionService.cs
@@ -1,6 +1,7 @@
 ﻿using bybit.net.api.Models;
 using bybit.net.api.Models.Account;
 using bybit.net.api.Models.Position;
+using bybit.net.api.Models.Position.Response;
 using bybit.net.api.Models.Trade;
 using bybit.net.api.Services;
 using System.Diagnostics;
@@ -38,7 +39,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Position Info</returns>
-        public async Task<string?> GetPositionInfo(Category category, string? symbol = null, string? baseCoin = null, string? settleCoin = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetPositionInfoResult>?> GetPositionInfo(Category category, string? symbol = null, string? baseCoin = null, string? settleCoin = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
@@ -49,7 +50,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(POSITION_LIST, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetPositionInfoResult>>(POSITION_LIST, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -64,7 +65,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="buyLeverage"></param>
         /// <param name="sellLeverage"></param>
         /// <returns>None</returns>
-        public async Task<string?> SetPositionLeverage(Category category, string symbol, string buyLeverage, string sellLeverage)
+        public async Task<GeneralResponse<object>?> SetPositionLeverage(Category category, string symbol, string buyLeverage, string sellLeverage)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
@@ -73,33 +74,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("buyLeverage", buyLeverage),
                 ("sellLeverage", sellLeverage)
             );
-            var result = await this.SendSignedAsync<string>(SET_LEVERAGE, HttpMethod.Post, query: query);
-            return result;
-        }
-
-        private const string SWITCH_MARGIN = "/v5/position/switch-isolated";
-        /// <summary>
-        /// Switch Cross/Isolated Margin Select cross margin mode or isolated margin mode per symbol level
-        /// Unified account covers: Inverse contract
-        /// Classic account covers: USDT perpetual / Inverse contract
-        /// </summary>
-        /// <param name="category"></param>
-        /// <param name="symbol"></param>
-        /// <param name="tradeMode"></param>
-        /// <param name="buyLeverage"></param>
-        /// <param name="sellLeverage"></param>
-        /// <returns>None</returns>
-        public async Task<string?> SwitchPositionMargin(Category category, string symbol, TradeMode tradeMode, string buyLeverage, string sellLeverage)
-        {
-            var query = new Dictionary<string, object> { { "category", category.Value } };
-
-            BybitParametersUtils.AddOptionalParameters(query,
-                ("symbol", symbol),
-                ("buyLeverage", buyLeverage),
-                ("sellLeverage", sellLeverage),
-                ("tradeMode", tradeMode.Value)
-            );
-            var result = await this.SendSignedAsync<string>(SWITCH_MARGIN, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(SET_LEVERAGE, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -115,18 +90,18 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="category"></param>
         /// <param name="symbol"></param>
         /// <param name="coin"></param>
-        /// <param name="positionMode"></param>
+        /// <param name="mode"></param>
         /// <returns>None</returns>
-        public async Task<string?> SwitchPositionMode(Category category, string? symbol = null, string? coin = null, PositionMode? positionMode = null)
+        public async Task<GeneralResponse<object>?> SwitchPositionMode(Category category, PositionMode mode, string? symbol = null, string? coin = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("symbol", symbol),
                  ("coin", coin),
-                ("positionMode", positionMode?.Value)
+                ("mode", mode.Value)
             );
-            var result = await this.SendSignedAsync<string>(SWITCH_POSITION_MODE, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(SWITCH_POSITION_MODE, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -142,11 +117,12 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="category"></param>
         /// <param name="symbol"></param>
-        /// <param name="positionIndex"></param>
+        /// <param name="positionIdx"></param>
         /// <param name="takeProfit"></param>
         /// <param name="stopLoss"></param>
         /// <param name="tpTriggerBy"></param>
         /// <param name="slTriggerBy"></param>
+        /// <param name="activePrice"></param>
         /// <param name="trailingStop"></param>
         /// <param name="tpslMode"></param>
         /// <param name="tpSize"></param>
@@ -156,19 +132,19 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="tpOrderType"></param>
         /// <param name="slOrderType"></param>
         /// <returns>None</returns>
-        public async Task<string?> SetPositionTradingStop(Category category, string symbol, PositionIndex positionIndex, string? takeProfit = null,
-        string? stopLoss = null, TriggerBy? tpTriggerBy = null, TriggerBy? slTriggerBy = null, string? trailingStop = null, TpslMode? tpslMode = null,
+        public async Task<GeneralResponse<object>?> SetPositionTradingStop(Category category, string symbol, TpslMode tpslMode, PositionIndex positionIdx, string? takeProfit = null,
+        string? stopLoss = null, TriggerBy? tpTriggerBy = null, TriggerBy? slTriggerBy = null, string? activePrice = null, string? trailingStop = null,
                                                 string? tpSize = null, string? slSize = null, string? tpLimitPrice = null, string? slLimitPrice = null, OrderType? tpOrderType = null, OrderType? slOrderType = null)
         {
-            var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol }, { "positionIndex", positionIndex.Value } };
+            var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol }, { "tpslMode", tpslMode.Value }, { "positionIdx", positionIdx.Value } };
 
             BybitParametersUtils.AddOptionalParameters(query,
                 ("takeProfit", takeProfit),
                 ("stopLoss", stopLoss),
                 ("tpTriggerBy", tpTriggerBy?.Value),
                 ("slTriggerBy", slTriggerBy?.Value),
+                ("activePrice", activePrice),
                 ("trailingStop", trailingStop),
-                ("tpslMode", tpslMode?.Value),
                  ("tpSize", tpSize),
                 ("slSize", slSize),
                 ("tpLimitPrice", tpLimitPrice),
@@ -176,7 +152,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("tpOrderType", tpOrderType?.Value),
                 ("slOrderType", slOrderType?.Value)
             );
-            var result = await this.SendSignedAsync<string>(SET_TRADING_STOP, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(SET_TRADING_STOP, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -191,11 +167,13 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="autoAddMargin"></param>
         /// <param name="positionIdx"></param>
         /// <returns>None</returns>
-        public async Task<string?> SetPositionAutoAddMargin(Category category, string symbol, AutoAddMargin autoAddMargin, PositionIndex positionIdx)
+        public async Task<GeneralResponse<object>?> SetPositionAutoAddMargin(Category category, string symbol, AutoAddMargin autoAddMargin, PositionIndex? positionIdx = null)
         {
-            var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol }, { "autoAddMargin", autoAddMargin.Value }, { "positionIdx", positionIdx.Value } };
+            var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol }, { "autoAddMargin", autoAddMargin.Value } };
 
-            var result = await this.SendSignedAsync<string>(SET_AUTO_ADD_MARGIN, HttpMethod.Post, query: query);
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("positionIdx", positionIdx?.Value));
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(SET_AUTO_ADD_MARGIN, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -210,12 +188,12 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="margin"></param>
         /// <param name="positionIdx"></param>
         /// <returns>Position Margin</returns>
-        public async Task<string?> SetPositionUpdateMargin(Category category, string symbol, string margin, PositionIndex? positionIdx = null)
+        public async Task<GeneralResponse<PositionMarginResult>?> SetPositionUpdateMargin(Category category, string symbol, string margin, PositionIndex? positionIdx = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol }, { "margin", margin }, };
             BybitParametersUtils.AddOptionalParameters(query,
                ("positionIdx", positionIdx?.Value));
-            var result = await this.SendSignedAsync<string>(UPDATE_MARGIN, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<PositionMarginResult>>(UPDATE_MARGIN, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -233,7 +211,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Close PNL</returns>
-        public async Task<string?> GetClosedPnl(Category category, string? symbol = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetClosedPnlResult>?> GetClosedPnl(Category category, string? symbol = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
@@ -244,7 +222,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(CLOSE_PNL, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetClosedPnlResult>>(CLOSE_PNL, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -259,10 +237,10 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="category"></param>
         /// <param name="symbol"></param>
         /// <returns>None</returns>
-        public async Task<string?> ConfirmPositionRiskLimit(Category category, string symbol)
+        public async Task<GeneralResponse<object>?> ConfirmPositionRiskLimit(Category category, string symbol)
         {
             var query = new Dictionary<string, object> { { "category", category.Value }, { "symbol", symbol } };
-            var result = await this.SendSignedAsync<string>(CONFIRM_NEW_RISK_LIMIT, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<object>>(CONFIRM_NEW_RISK_LIMIT, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -280,10 +258,10 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="fromUid"></param>
         /// <param name="toUid"></param>
         /// <returns>Move Position</returns>
-        public async Task<string?> MovePosition(string fromUid, string toUid, List<Dictionary<string, object>> list)
+        public async Task<GeneralResponse<MovePositionResult>?> MovePosition(string fromUid, string toUid, List<Dictionary<string, object>> list)
         {
             var query = new Dictionary<string, object> { { "fromUid", fromUid }, { "toUid", toUid }, { "list", list } };
-            var result = await this.SendSignedAsync<string>(MOVE_POSITION, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<MovePositionResult>>(MOVE_POSITION, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -300,10 +278,10 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="fromUid"></param>
         /// <param name="toUid"></param>
         /// <returns>Move Position</returns>
-        public async Task<string?> MovePosition(string fromUid, string toUid, List<MovePositionRequest> list)
+        public async Task<GeneralResponse<MovePositionResult>?> MovePosition(string fromUid, string toUid, List<MovePositionRequest> list)
         {
             var query = new Dictionary<string, object> { { "fromUid", fromUid }, { "toUid", toUid }, { "list", list } };
-            var result = await this.SendSignedAsync<string>(MOVE_POSITION, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<MovePositionResult>>(MOVE_POSITION, HttpMethod.Post, query: query);
             return result;
         }
 
@@ -321,7 +299,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns>Move Position History</returns>
-        public async Task<string?> GetMovePositionHistory(Category? category = null, string? symbol = null, int? startTime = null, int? endTime = null, string? status = null, string? blockTradeId = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetMovePositionHistoryResult>?> GetMovePositionHistory(Category? category = null, string? symbol = null, long? startTime = null, long? endTime = null, string? status = null, string? blockTradeId = null, string? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { };
 
@@ -335,7 +313,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(MOVE_POSITION_HISTORY, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetMovePositionHistoryResult>>(MOVE_POSITION_HISTORY, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -352,7 +330,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <param name="limit"></param>
         /// <param name="cursor"></param>
         /// <returns></returns>
-        public async Task<string?> GetClosedOptionsPositions(Category category, string? symbol = null, int? startTime = null, int? endTime = null, int? limit = null, string? cursor = null)
+        public async Task<GeneralResponse<GetClosedOptionsPositionsResult>?> GetClosedOptionsPositions(Category category, string? symbol = null, long? startTime = null, long? endTime = null, int? limit = null, string? cursor = null)
         {
             var query = new Dictionary<string, object> { { "category", category.Value } };
 
@@ -363,7 +341,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("limit", limit),
                 ("cursor", cursor)
             );
-            var result = await this.SendSignedAsync<string>(GET_CLOSED_OPTIONS_POSITIONS, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<GeneralResponse<GetClosedOptionsPositionsResult>>(GET_CLOSED_OPTIONS_POSITIONS, HttpMethod.Get, query: query);
             return result;
         }
     }

--- a/Src/Common/ApiServiceImp/BybitRFQService.cs
+++ b/Src/Common/ApiServiceImp/BybitRFQService.cs
@@ -139,6 +139,26 @@ namespace bybit.net.api.ApiServiceImp
             return result;
         }
 
+        private const string ACCEPT_OTHER_QUOTE = "/v5/rfq/accept-other-quote";
+
+        /// <summary>
+        /// Accept non-LP Quote — POST /v5/rfq/accept-other-quote
+        /// </summary>
+        public async Task<string?> AcceptOtherQuote(string rfqId)
+        {
+            var body = new Dictionary<string, object>
+            {
+                { "rfqId", rfqId }
+            };
+
+            var result = await this.SendSignedAsync<string>(
+                ACCEPT_OTHER_QUOTE,
+                HttpMethod.Post,
+                query: body);
+
+            return result;
+        }
+
         private const string EXECUTE_QUOTE = "/v5/rfq/execute-quote";
 
         /// <summary>

--- a/Src/Common/ApiServiceImp/BybitRateLimitService.cs
+++ b/Src/Common/ApiServiceImp/BybitRateLimitService.cs
@@ -1,4 +1,5 @@
 ﻿using bybit.net.api.Models.RateLimit;
+using bybit.net.api.Models;
 using bybit.net.api.Services;
 using System;
 using System.Collections.Generic;
@@ -25,14 +26,14 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Set Rate Limit — POST /v5/apilimit/set
         /// </summary>
-        public async Task<string?> SetApiRateLimit(IEnumerable<ApiRateLimitSetItem> list)
+        public async Task<GeneralResponse<SetApiRateLimitResponse>?> SetApiRateLimit(IEnumerable<ApiRateLimitSetItem> list)
         {
             var body = new Dictionary<string, object>
             {
                 { "list", list?.ToArray() ?? Array.Empty<ApiRateLimitSetItem>() }
             };
 
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<SetApiRateLimitResponse>>(
                 SET_API_RATE_LIMIT,
                 HttpMethod.Post,
                 query: body);
@@ -45,14 +46,14 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Get Rate Limit — GET /v5/apilimit/query
         /// </summary>
-        public async Task<string?> GetApiRateLimit(string uids)
+        public async Task<GeneralResponse<GetApiRateLimitResponse>?> GetApiRateLimit(string uids)
         {
             var query = new Dictionary<string, object>
             {
                 { "uids", uids }
             };
 
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<GetApiRateLimitResponse>>(
                 GET_API_RATE_LIMIT,
                 HttpMethod.Get,
                 query: query);
@@ -65,10 +66,10 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Get Rate Limit Cap — GET /v5/apilimit/query-cap
         /// </summary>
-        public async Task<string?> GetApiRateLimitCap()
+        public async Task<GeneralResponse<GetApiRateLimitCapResponse>?> GetApiRateLimitCap()
         {
             var query = new Dictionary<string, object>();
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<GetApiRateLimitCapResponse>>(
                 GET_API_RATE_LIMIT_CAP,
                 HttpMethod.Get,
                 query: query);
@@ -81,7 +82,7 @@ namespace bybit.net.api.ApiServiceImp
         /// <summary>
         /// Get All Rate Limits — GET /v5/apilimit/query-all
         /// </summary>
-        public async Task<string?> GetAllApiRateLimits(
+        public async Task<GeneralResponse<GetAllApiRateLimitsResponse>?> GetAllApiRateLimits(
             string? limit = null,     // [1, 1000], default 1000
             string? cursor = null,
             string? uids = null)      // comma-separated; across different masters
@@ -94,7 +95,7 @@ namespace bybit.net.api.ApiServiceImp
                 ("uids", uids)
             );
 
-            var result = await this.SendSignedAsync<string>(
+            var result = await this.SendSignedAsync<GeneralResponse<GetAllApiRateLimitsResponse>>(
                 GET_API_RATE_LIMIT_ALL,
                 HttpMethod.Get,
                 query: query);

--- a/Src/Common/ApiServiceImp/BybitSpotMarginService.cs
+++ b/Src/Common/ApiServiceImp/BybitSpotMarginService.cs
@@ -204,10 +204,23 @@ namespace bybit.net.api.ApiServiceImp
         /// </summary>
         /// <param name="spotMarginMode"></param>
         /// <returns>Toggle Margin Trade</returns>
-        public async Task<string?> GetSpotMarginVipData(SpotMarginMode spotMarginMode)
+        public async Task<string?> SwitchSpotMarginMode(SpotMarginMode spotMarginMode)
         {
             var query = new Dictionary<string, object> { { "spotMarginMode", spotMarginMode.Value } };
-            var result = await this.SendSignedAsync<string>(TOOGLE_MARGIN_TRADE, HttpMethod.Get, query: query);
+            var result = await this.SendSignedAsync<string>(TOOGLE_MARGIN_TRADE, HttpMethod.Post, query: query);
+            return result;
+        }
+
+        /// <summary>
+        /// Turn on / off spot margin trade
+        /// Covers: Margin trade(Unified Account)
+        /// Your account needs to activate spot margin first; i.e., you must have finished the quiz on web / app.
+        /// </summary>
+        /// <param name="spotMarginMode"></param>
+        /// <returns>Toggle Margin Trade</returns>
+        public async Task<string?> GetSpotMarginVipData(SpotMarginMode spotMarginMode)
+        {
+            var result = await SwitchSpotMarginMode(spotMarginMode);
             return result;
         }
 
@@ -218,10 +231,14 @@ namespace bybit.net.api.ApiServiceImp
         /// Your account needs to activate spot margin first; i.e., you must have finished the quiz on web / app.
         /// </summary>
         /// <param name="leverage"></param>
+        /// <param name="currency"></param>
         /// <returns>Set Leverage</returns>
-        public async Task<string?> SetSpotMarginLeverage(string leverage)
+        public async Task<string?> SetSpotMarginLeverage(string leverage, string? currency = null)
         {
             var query = new Dictionary<string, object> { { "leverage", leverage } };
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
             var result = await this.SendSignedAsync<string>(SET_SPOT_MARGIN_LEVERAGE, HttpMethod.Post, query: query);
             return result;
         }
@@ -235,7 +252,94 @@ namespace bybit.net.api.ApiServiceImp
         public async Task<string?> GetSpotMarginState()
         {
             var query = new Dictionary<string, object> { };
-            var result = await this.SendSignedAsync<string>(SPOT_MARGIN_STATE, HttpMethod.Post, query: query);
+            var result = await this.SendSignedAsync<string>(SPOT_MARGIN_STATE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_CURRENCY_DATA = "/v5/spot-margin-trade/currency-data";
+
+        /// <summary>
+        /// Get currency data
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Currency data</returns>
+        public async Task<string?> GetSpotMarginCurrencyData(string? currency = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_CURRENCY_DATA, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_COIN_STATE = "/v5/spot-margin-trade/coinstate";
+
+        /// <summary>
+        /// Get coin state
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Coin state</returns>
+        public async Task<string?> GetSpotMarginCoinState(string? currency = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_COIN_STATE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_POSITION_TIERS = "/v5/spot-margin-trade/position-tiers";
+
+        /// <summary>
+        /// Get Position Tiers
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Position tiers</returns>
+        public async Task<string?> GetSpotMarginPositionTiers(string? currency = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_POSITION_TIERS, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_MAX_BORROWABLE = "/v5/spot-margin-trade/max-borrowable";
+
+        /// <summary>
+        /// Get Max Borrowable Amount
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Max borrowable amount</returns>
+        public async Task<string?> GetSpotMarginMaxBorrowable(string currency)
+        {
+            var query = new Dictionary<string, object> { { "currency", currency } };
+            var result = await this.SendSignedAsync<string>(GET_MAX_BORROWABLE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_REPAYMENT_AVAILABLE_AMOUNT = "/v5/spot-margin-trade/repayment-available-amount";
+
+        /// <summary>
+        /// Get Available Amount to Repay
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Repayment available amount</returns>
+        public async Task<string?> GetSpotMarginRepaymentAvailableAmount(string currency)
+        {
+            var query = new Dictionary<string, object> { { "currency", currency } };
+            var result = await this.SendSignedAsync<string>(GET_REPAYMENT_AVAILABLE_AMOUNT, HttpMethod.Get, query: query);
             return result;
         }
 
@@ -283,6 +387,192 @@ namespace bybit.net.api.ApiServiceImp
             );
 
             var result = await this.SendSignedAsync<string>(GET_HISTORICAL_INTEREST_RATE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string SET_AUTO_REPAY_MODE = "/v5/spot-margin-trade/set-auto-repay-mode";
+
+        /// <summary>
+        /// Set Auto Repay Mode
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="autoRepayMode">1: On, 0: Off</param>
+        /// <param name="currency"></param>
+        /// <returns>Auto repay mode</returns>
+        public async Task<string?> SetAutoRepayMode(string autoRepayMode, string? currency = null)
+        {
+            var query = new Dictionary<string, object> { { "autoRepayMode", autoRepayMode } };
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            var result = await this.SendSignedAsync<string>(SET_AUTO_REPAY_MODE, HttpMethod.Post, query: query);
+            return result;
+        }
+
+        private const string GET_AUTO_REPAY_MODE = "/v5/spot-margin-trade/get-auto-repay-mode";
+
+        /// <summary>
+        /// Get Auto Repay Mode
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Auto repay mode</returns>
+        public async Task<string?> GetAutoRepayMode(string? currency = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("currency", currency)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_AUTO_REPAY_MODE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_FIXED_BORROW_ORDER_QUOTE = "/v5/spot-margin-trade/fixedborrow-order-quote";
+
+        /// <summary>
+        /// Get Fixed-Rate Borrow Order Quote
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="orderCurrency"></param>
+        /// <param name="term"></param>
+        /// <param name="orderBy"></param>
+        /// <param name="sort"></param>
+        /// <param name="limit"></param>
+        /// <returns>Fixed-rate borrow order quote</returns>
+        public async Task<string?> GetFixedBorrowOrderQuote(string orderCurrency, string? term = null, string? orderBy = null, int? sort = null, int? limit = null)
+        {
+            var query = new Dictionary<string, object> { { "orderCurrency", orderCurrency } };
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("term", term),
+                ("orderBy", orderBy),
+                ("sort", sort),
+                ("limit", limit)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_FIXED_BORROW_ORDER_QUOTE, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string FIXED_BORROW = "/v5/spot-margin-trade/fixedborrow";
+
+        /// <summary>
+        /// Fixed-Rate Borrow
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="orderCurrency"></param>
+        /// <param name="orderAmount"></param>
+        /// <param name="annualRate"></param>
+        /// <param name="term"></param>
+        /// <param name="repayType"></param>
+        /// <returns>Fixed-rate borrow</returns>
+        public async Task<string?> FixedBorrow(string orderCurrency, string orderAmount, string annualRate, string term, string? repayType = null)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "orderCurrency", orderCurrency },
+                { "orderAmount", orderAmount },
+                { "annualRate", annualRate },
+                { "term", term }
+            };
+
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("repayType", repayType)
+            );
+
+            var result = await this.SendSignedAsync<string>(FIXED_BORROW, HttpMethod.Post, query: query);
+            return result;
+        }
+
+        private const string FIXED_BORROW_RENEW = "/v5/spot-margin-trade/fixedborrow-renew";
+
+        /// <summary>
+        /// Renew Fixed-Rate Borrow
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="loanId"></param>
+        /// <param name="qty"></param>
+        /// <returns>Renew fixed-rate borrow</returns>
+        public async Task<string?> RenewFixedBorrow(string loanId, string? qty = null)
+        {
+            var query = new Dictionary<string, object> { { "loanId", loanId } };
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("qty", qty)
+            );
+
+            var result = await this.SendSignedAsync<string>(FIXED_BORROW_RENEW, HttpMethod.Post, query: query);
+            return result;
+        }
+
+        private const string GET_FIXED_BORROW_ORDER_INFO = "/v5/spot-margin-trade/fixedborrow-order-info";
+
+        /// <summary>
+        /// Get Fixed-Rate Borrow Order Info
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <param name="orderCurrency"></param>
+        /// <param name="state"></param>
+        /// <param name="term"></param>
+        /// <param name="limit"></param>
+        /// <param name="cursor"></param>
+        /// <returns>Fixed-rate borrow order info</returns>
+        public async Task<string?> GetFixedBorrowOrderInfo(string? orderId = null, string? orderCurrency = null, string? state = null, string? term = null, string? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("orderId", orderId),
+                ("orderCurrency", orderCurrency),
+                ("state", state),
+                ("term", term),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_FIXED_BORROW_ORDER_INFO, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_FIXED_BORROW_CONTRACT_INFO = "/v5/spot-margin-trade/fixedborrow-contract-info";
+
+        /// <summary>
+        /// Get Fixed-Rate Borrow Contract Info
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <param name="orderCurrency"></param>
+        /// <param name="term"></param>
+        /// <param name="limit"></param>
+        /// <param name="cursor"></param>
+        /// <returns>Fixed-rate borrow contract info</returns>
+        public async Task<string?> GetFixedBorrowContractInfo(string? orderId = null, string? orderCurrency = null, string? term = null, string? limit = null, string? cursor = null)
+        {
+            var query = new Dictionary<string, object>();
+            BybitParametersUtils.AddOptionalParameters(query,
+                ("orderId", orderId),
+                ("orderCurrency", orderCurrency),
+                ("term", term),
+                ("limit", limit),
+                ("cursor", cursor)
+            );
+
+            var result = await this.SendSignedAsync<string>(GET_FIXED_BORROW_CONTRACT_INFO, HttpMethod.Get, query: query);
+            return result;
+        }
+
+        private const string GET_LIABILITY = "/v5/spot-margin-trade/liability";
+
+        /// <summary>
+        /// Get Liability Info
+        /// Covers: Margin trade(Unified Account)
+        /// </summary>
+        /// <param name="currency"></param>
+        /// <returns>Liability info</returns>
+        public async Task<string?> GetSpotMarginLiability(string currency)
+        {
+            var query = new Dictionary<string, object> { { "currency", currency } };
+            var result = await this.SendSignedAsync<string>(GET_LIABILITY, HttpMethod.Get, query: query);
             return result;
         }
 

--- a/Src/Common/ApiServiceImp/BybitSpreadTradingService.cs
+++ b/Src/Common/ApiServiceImp/BybitSpreadTradingService.cs
@@ -136,6 +136,34 @@ namespace bybit.net.api.ApiServiceImp
             return result;
         }
 
+        private const string GET_SPREAD_MAX_ORDER_QTY = "/v5/spread/max-qty";
+
+        /// <summary>
+        /// Get Max Qty
+        /// Query the maximum order quantity for the given symbol.
+        /// HTTP GET /v5/spread/max-qty
+        /// </summary>
+        /// <param name="symbol">Spread combination symbol name (required)</param>
+        /// <param name="side">Order side: 1 Buy, 2 Sell (required)</param>
+        /// <param name="orderPrice">Order price (required)</param>
+        /// <returns>Raw JSON string</returns>
+        public async Task<string?> GetSpreadMaxOrderQty(string symbol, string side, string orderPrice)
+        {
+            var query = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "side", side },
+                { "orderPrice", orderPrice }
+            };
+
+            var result = await this.SendSignedAsync<string>(
+                GET_SPREAD_MAX_ORDER_QTY,
+                HttpMethod.Get,
+                query: query);
+
+            return result;
+        }
+
         private const string CREATE_SPREAD_ORDER = "/v5/spread/order/create";
 
         /// <summary>

--- a/Src/Common/Models/Account/DeltaNeutralMode.cs
+++ b/Src/Common/Models/Account/DeltaNeutralMode.cs
@@ -1,0 +1,20 @@
+namespace bybit.net.api.Models.Account
+{
+    public struct DeltaNeutralMode
+    {
+        private DeltaNeutralMode(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; private set; }
+
+        public static DeltaNeutralMode Enable => new("1");
+
+        public static DeltaNeutralMode Disable => new("0");
+
+        public override readonly string ToString() => Value;
+
+        public static implicit operator string(DeltaNeutralMode deltaNeutralMode) => deltaNeutralMode.Value;
+    }
+}

--- a/Src/Common/Models/Account/ManualRepayRequest.cs
+++ b/Src/Common/Models/Account/ManualRepayRequest.cs
@@ -1,0 +1,11 @@
+namespace bybit.net.api.Models.Account
+{
+    public class ManualRepayRequest
+    {
+        public string? Coin { get; set; }
+
+        public string? Amount { get; set; }
+
+        public RepaymentType? RepaymentType { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/NoConvertRepayRequest.cs
+++ b/Src/Common/Models/Account/NoConvertRepayRequest.cs
@@ -1,0 +1,11 @@
+namespace bybit.net.api.Models.Account
+{
+    public class NoConvertRepayRequest
+    {
+        public string? Coin { get; set; }
+
+        public string? Amount { get; set; }
+
+        public RepaymentType? RepaymentType { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/RepaymentType.cs
+++ b/Src/Common/Models/Account/RepaymentType.cs
@@ -1,0 +1,22 @@
+namespace bybit.net.api.Models.Account
+{
+    public struct RepaymentType
+    {
+        private RepaymentType(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; private set; }
+
+        public static RepaymentType All => new("ALL");
+
+        public static RepaymentType Fixed => new("FIXED");
+
+        public static RepaymentType Flexible => new("FLEXIBLE");
+
+        public override readonly string ToString() => Value;
+
+        public static implicit operator string(RepaymentType repaymentType) => repaymentType.Value;
+    }
+}

--- a/Src/Common/Models/Account/Response/GetAccountInstrumentsInfoResult.cs
+++ b/Src/Common/Models/Account/Response/GetAccountInstrumentsInfoResult.cs
@@ -1,0 +1,220 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class GetAccountInstrumentsInfoResult
+    {
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+
+        [JsonProperty("list")]
+        public List<AccountInstrumentInfo>? List { get; set; }
+    }
+
+    public class AccountInstrumentInfo
+    {
+        [JsonProperty("symbol")]
+        public string? Symbol { get; set; }
+
+        [JsonProperty("contractType")]
+        public string? ContractType { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("baseCoin")]
+        public string? BaseCoin { get; set; }
+
+        [JsonProperty("quoteCoin")]
+        public string? QuoteCoin { get; set; }
+
+        [JsonProperty("symbolType")]
+        public string? SymbolType { get; set; }
+
+        [JsonProperty("launchTime")]
+        public string? LaunchTime { get; set; }
+
+        [JsonProperty("deliveryTime")]
+        public string? DeliveryTime { get; set; }
+
+        [JsonProperty("deliveryFeeRate")]
+        public string? DeliveryFeeRate { get; set; }
+
+        [JsonProperty("priceScale")]
+        public string? PriceScale { get; set; }
+
+        [JsonProperty("leverageFilter")]
+        public AccountInstrumentLeverageFilter? LeverageFilter { get; set; }
+
+        [JsonProperty("priceFilter")]
+        public AccountInstrumentPriceFilter? PriceFilter { get; set; }
+
+        [JsonProperty("lotSizeFilter")]
+        public AccountInstrumentLotSizeFilter? LotSizeFilter { get; set; }
+
+        [JsonProperty("unifiedMarginTrade")]
+        public bool? UnifiedMarginTrade { get; set; }
+
+        [JsonProperty("fundingInterval")]
+        public int? FundingInterval { get; set; }
+
+        [JsonProperty("settleCoin")]
+        public string? SettleCoin { get; set; }
+
+        [JsonProperty("copyTrading")]
+        public string? CopyTrading { get; set; }
+
+        [JsonProperty("upperFundingRate")]
+        public string? UpperFundingRate { get; set; }
+
+        [JsonProperty("lowerFundingRate")]
+        public string? LowerFundingRate { get; set; }
+
+        [JsonProperty("displayName")]
+        public string? DisplayName { get; set; }
+
+        [JsonProperty("riskParameters")]
+        public AccountInstrumentRiskParameters? RiskParameters { get; set; }
+
+        [JsonProperty("isPreListing")]
+        public bool? IsPreListing { get; set; }
+
+        [JsonProperty("preListingInfo")]
+        public AccountInstrumentPreListingInfo? PreListingInfo { get; set; }
+
+        [JsonProperty("isPublicRpi")]
+        public bool? IsPublicRpi { get; set; }
+
+        [JsonProperty("myRpiPermission")]
+        public bool? MyRpiPermission { get; set; }
+
+        [JsonProperty("innovation")]
+        public string? Innovation { get; set; }
+
+        [JsonProperty("xstockMultiplier")]
+        public string? XstockMultiplier { get; set; }
+
+        [JsonProperty("marginTrading")]
+        public string? MarginTrading { get; set; }
+
+        [JsonProperty("stTag")]
+        public string? StTag { get; set; }
+    }
+
+    public class AccountInstrumentLeverageFilter
+    {
+        [JsonProperty("minLeverage")]
+        public string? MinLeverage { get; set; }
+
+        [JsonProperty("maxLeverage")]
+        public string? MaxLeverage { get; set; }
+
+        [JsonProperty("leverageStep")]
+        public string? LeverageStep { get; set; }
+    }
+
+    public class AccountInstrumentPriceFilter
+    {
+        [JsonProperty("minPrice")]
+        public string? MinPrice { get; set; }
+
+        [JsonProperty("maxPrice")]
+        public string? MaxPrice { get; set; }
+
+        [JsonProperty("tickSize")]
+        public string? TickSize { get; set; }
+    }
+
+    public class AccountInstrumentLotSizeFilter
+    {
+        [JsonProperty("basePrecision")]
+        public string? BasePrecision { get; set; }
+
+        [JsonProperty("quotePrecision")]
+        public string? QuotePrecision { get; set; }
+
+        [JsonProperty("minOrderQty")]
+        public string? MinOrderQty { get; set; }
+
+        [JsonProperty("maxOrderQty")]
+        public string? MaxOrderQty { get; set; }
+
+        [JsonProperty("minOrderAmt")]
+        public string? MinOrderAmt { get; set; }
+
+        [JsonProperty("maxOrderAmt")]
+        public string? MaxOrderAmt { get; set; }
+
+        [JsonProperty("maxLimitOrderQty")]
+        public string? MaxLimitOrderQty { get; set; }
+
+        [JsonProperty("maxMarketOrderQty")]
+        public string? MaxMarketOrderQty { get; set; }
+
+        [JsonProperty("postOnlyMaxLimitOrderSize")]
+        public string? PostOnlyMaxLimitOrderSize { get; set; }
+
+        [JsonProperty("maxMktOrderQty")]
+        public string? MaxMktOrderQty { get; set; }
+
+        [JsonProperty("minNotionalValue")]
+        public string? MinNotionalValue { get; set; }
+
+        [JsonProperty("qtyStep")]
+        public string? QtyStep { get; set; }
+
+        [JsonProperty("postOnlyMaxOrderQty")]
+        public string? PostOnlyMaxOrderQty { get; set; }
+    }
+
+    public class AccountInstrumentRiskParameters
+    {
+        [JsonProperty("priceLimitRatioX")]
+        public string? PriceLimitRatioX { get; set; }
+
+        [JsonProperty("priceLimitRatioY")]
+        public string? PriceLimitRatioY { get; set; }
+    }
+
+    public class AccountInstrumentPreListingInfo
+    {
+        [JsonProperty("curAuctionPhase")]
+        public string? CurAuctionPhase { get; set; }
+
+        [JsonProperty("phases")]
+        public List<AccountInstrumentPhase>? Phases { get; set; }
+
+        [JsonProperty("auctionFeeInfo")]
+        public AccountInstrumentAuctionFeeInfo? AuctionFeeInfo { get; set; }
+
+        [JsonProperty("skipCallAuction")]
+        public bool? SkipCallAuction { get; set; }
+    }
+
+    public class AccountInstrumentPhase
+    {
+        [JsonProperty("phase")]
+        public string? Phase { get; set; }
+
+        [JsonProperty("startTime")]
+        public string? StartTime { get; set; }
+
+        [JsonProperty("endTime")]
+        public string? EndTime { get; set; }
+    }
+
+    public class AccountInstrumentAuctionFeeInfo
+    {
+        [JsonProperty("auctionFeeRate")]
+        public string? AuctionFeeRate { get; set; }
+
+        [JsonProperty("takerFeeRate")]
+        public string? TakerFeeRate { get; set; }
+
+        [JsonProperty("makerFeeRate")]
+        public string? MakerFeeRate { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/GetOptionAssetInfoResult.cs
+++ b/Src/Common/Models/Account/Response/GetOptionAssetInfoResult.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class GetOptionAssetInfoResult
+    {
+        [JsonProperty("result")]
+        public List<OptionAssetInfoEntry>? Result { get; set; }
+    }
+
+    public class OptionAssetInfoEntry
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("totalDelta")]
+        public string? TotalDelta { get; set; }
+
+        [JsonProperty("totalRPL")]
+        public string? TotalRpl { get; set; }
+
+        [JsonProperty("totalUPL")]
+        public string? TotalUpl { get; set; }
+
+        [JsonProperty("assetIM")]
+        public string? AssetIm { get; set; }
+
+        [JsonProperty("assetMM")]
+        public string? AssetMm { get; set; }
+
+        [JsonProperty("sendTime")]
+        public long? SendTime { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/GetPayInfoResult.cs
+++ b/Src/Common/Models/Account/Response/GetPayInfoResult.cs
@@ -1,0 +1,61 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class GetPayInfoResult
+    {
+        [JsonProperty("collateralInfo")]
+        public PayCollateralInfo? CollateralInfo { get; set; }
+
+        [JsonProperty("borrowInfo")]
+        public PayBorrowInfo? BorrowInfo { get; set; }
+    }
+
+    public class PayCollateralInfo
+    {
+        [JsonProperty("collateralList")]
+        public List<PayCollateralEntry>? CollateralList { get; set; }
+    }
+
+    public class PayCollateralEntry
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("availableSize")]
+        public string? AvailableSize { get; set; }
+
+        [JsonProperty("availableValue")]
+        public string? AvailableValue { get; set; }
+
+        [JsonProperty("coinScale")]
+        public int? CoinScale { get; set; }
+
+        [JsonProperty("borrowSize")]
+        public string? BorrowSize { get; set; }
+
+        [JsonProperty("spotHedgeAmount")]
+        public string? SpotHedgeAmount { get; set; }
+
+        [JsonProperty("assetFrozen")]
+        public string? AssetFrozen { get; set; }
+    }
+
+    public class PayBorrowInfo
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("borrowSize")]
+        public string? BorrowSize { get; set; }
+
+        [JsonProperty("borrowValue")]
+        public string? BorrowValue { get; set; }
+
+        [JsonProperty("assetFrozen")]
+        public string? AssetFrozen { get; set; }
+
+        [JsonProperty("availableBalance")]
+        public string? AvailableBalance { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/GetTradeInfoForAnalysisResult.cs
+++ b/Src/Common/Models/Account/Response/GetTradeInfoForAnalysisResult.cs
@@ -1,0 +1,76 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class GetTradeInfoForAnalysisResult
+    {
+        [JsonProperty("symbolRnl")]
+        public string? SymbolRnl { get; set; }
+
+        [JsonProperty("netExecQty")]
+        public string? NetExecQty { get; set; }
+
+        [JsonProperty("sumExecValue")]
+        public string? SumExecValue { get; set; }
+
+        [JsonProperty("sumExecQty")]
+        public string? SumExecQty { get; set; }
+
+        [JsonProperty("avgBuyExecPrice")]
+        public string? AvgBuyExecPrice { get; set; }
+
+        [JsonProperty("sumBuyExecValue")]
+        public string? SumBuyExecValue { get; set; }
+
+        [JsonProperty("sumBuyExecQty")]
+        public string? SumBuyExecQty { get; set; }
+
+        [JsonProperty("sumBuyExecFee")]
+        public string? SumBuyExecFee { get; set; }
+
+        [JsonProperty("sumBuyOrderQty")]
+        public string? SumBuyOrderQty { get; set; }
+
+        [JsonProperty("avgSellExecPrice")]
+        public string? AvgSellExecPrice { get; set; }
+
+        [JsonProperty("sumSellExecValue")]
+        public string? SumSellExecValue { get; set; }
+
+        [JsonProperty("sumSellExecQty")]
+        public string? SumSellExecQty { get; set; }
+
+        [JsonProperty("sumSellExecFee")]
+        public string? SumSellExecFee { get; set; }
+
+        [JsonProperty("sumSellOrderQty")]
+        public string? SumSellOrderQty { get; set; }
+
+        [JsonProperty("maxMarginVersion")]
+        public int? MaxMarginVersion { get; set; }
+
+        [JsonProperty("baseCoin")]
+        public string? BaseCoin { get; set; }
+
+        [JsonProperty("settleCoin")]
+        public string? SettleCoin { get; set; }
+
+        [JsonProperty("sumPriceList")]
+        public List<TradeInfoPriceSummary>? SumPriceList { get; set; }
+    }
+
+    public class TradeInfoPriceSummary
+    {
+        [JsonProperty("day")]
+        public string? Day { get; set; }
+
+        [JsonProperty("sumBuyExecValue")]
+        public string? SumBuyExecValue { get; set; }
+
+        [JsonProperty("sumSellExecValue")]
+        public string? SumSellExecValue { get; set; }
+
+        [JsonProperty("sumExecValue")]
+        public string? SumExecValue { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/GetTransferableAmountResult.cs
+++ b/Src/Common/Models/Account/Response/GetTransferableAmountResult.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class GetTransferableAmountResult
+    {
+        [JsonProperty("availableWithdrawal")]
+        public string? AvailableWithdrawal { get; set; }
+
+        [JsonProperty("availableWithdrawalMap")]
+        public Dictionary<string, string>? AvailableWithdrawalMap { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/ManualBorrowResult.cs
+++ b/Src/Common/Models/Account/Response/ManualBorrowResult.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class ManualBorrowResult
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/ManualRepayResult.cs
+++ b/Src/Common/Models/Account/Response/ManualRepayResult.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class ManualRepayResult
+    {
+        [JsonProperty("resultStatus")]
+        public string? ResultStatus { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/SetDeltaModeResult.cs
+++ b/Src/Common/Models/Account/Response/SetDeltaModeResult.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class SetDeltaModeResult
+    {
+        [JsonProperty("resultStatus")]
+        public string? ResultStatus { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/Response/SetMarginModeResult.cs
+++ b/Src/Common/Models/Account/Response/SetMarginModeResult.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Account.Response
+{
+    public class SetMarginModeResult
+    {
+        [JsonProperty("reasons")]
+        public List<SetMarginModeReason>? Reasons { get; set; }
+    }
+
+    public class SetMarginModeReason
+    {
+        [JsonProperty("reasonCode")]
+        public string? ReasonCode { get; set; }
+
+        [JsonProperty("reasonMsg")]
+        public string? ReasonMsg { get; set; }
+    }
+}

--- a/Src/Common/Models/Account/SetDeltaModeRequest.cs
+++ b/Src/Common/Models/Account/SetDeltaModeRequest.cs
@@ -1,0 +1,7 @@
+namespace bybit.net.api.Models.Account
+{
+    public class SetDeltaModeRequest
+    {
+        public DeltaNeutralMode DeltaEnable { get; set; }
+    }
+}

--- a/Src/Common/Models/Affiliate/GetAffiliateUserInfoResult.cs
+++ b/Src/Common/Models/Affiliate/GetAffiliateUserInfoResult.cs
@@ -1,27 +1,61 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace bybit.net.api.Models.Affiliate
 {
     public class GetAffiliateUserInfoResult
     {
-        public string? uid { get; set; }
-        public string? vipLevel { get; set; }
-        public string? takerVol30Day { get; set; }       // USDT
-        public string? makerVol30Day { get; set; }       // USDT
-        public string? tradeVol30Day { get; set; }       // USDT
-        public string? depositAmount30Day { get; set; }  // USDT, ~5 min update
-        public string? takerVol365Day { get; set; }      // USDT
-        public string? makerVol365Day { get; set; }      // USDT
-        public string? tradeVol365Day { get; set; }      // USDT
-        public string? depositAmount365Day { get; set; } // USDT, ~5 min update
-        public string? totalWalletBalance { get; set; }  // 1..4
-        public string? depositUpdateTime { get; set; }   // UTC
-        public string? volUpdateTime { get; set; }       // UTC
-        public int? KycLevel { get; set; }               // 0,1,2
-    }
+        [JsonProperty("uid")]
+        public string? Uid { get; set; }
 
+        [JsonProperty("vipLevel")]
+        public string? VipLevel { get; set; }
+
+        [JsonProperty("takerVol30Day")]
+        public string? TakerVol30Day { get; set; }
+
+        [JsonProperty("makerVol30Day")]
+        public string? MakerVol30Day { get; set; }
+
+        [JsonProperty("tradeVol30Day")]
+        public string? TradeVol30Day { get; set; }
+
+        [JsonProperty("depositAmount30Day")]
+        public string? DepositAmount30Day { get; set; }
+
+        [JsonProperty("takerVol365Day")]
+        public string? TakerVol365Day { get; set; }
+
+        [JsonProperty("makerVol365Day")]
+        public string? MakerVol365Day { get; set; }
+
+        [JsonProperty("tradeVol365Day")]
+        public string? TradeVol365Day { get; set; }
+
+        [JsonProperty("depositAmount365Day")]
+        public string? DepositAmount365Day { get; set; }
+
+        [JsonProperty("totalWalletBalance")]
+        public string? TotalWalletBalance { get; set; }
+
+        [JsonProperty("depositUpdateTime")]
+        public string? DepositUpdateTime { get; set; }
+
+        [JsonProperty("volUpdateTime")]
+        public string? VolUpdateTime { get; set; }
+
+        [JsonProperty("KycLevel")]
+        public int? KycLevel { get; set; }
+
+        [JsonProperty("tradfiTradeVol30Day")]
+        public string? TradfiTradeVol30Day { get; set; }
+
+        [JsonProperty("tradfiTradeVol365Day")]
+        public string? TradfiTradeVol365Day { get; set; }
+
+        [JsonProperty("commissions30Day")]
+        public Dictionary<string, string>? Commissions30Day { get; set; }
+
+        [JsonProperty("commissions365Day")]
+        public Dictionary<string, string>? Commissions365Day { get; set; }
+    }
 }

--- a/Src/Common/Models/Affiliate/GetAffiliateUserListResult.cs
+++ b/Src/Common/Models/Affiliate/GetAffiliateUserListResult.cs
@@ -1,32 +1,88 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace bybit.net.api.Models.Affiliate
 {
     public class GetAffiliateUserListResult
     {
-        public List<AffiliateUser>? list { get; set; }
-        public string? nextPageCursor { get; set; }
+        [JsonProperty("list")]
+        public List<AffiliateUser>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
     }
 
     public class AffiliateUser
     {
-        public string? userId { get; set; }
-        public string? registerTime { get; set; }
-        public int? source { get; set; }
-        public int? remarks { get; set; }
-        public bool? isKyc { get; set; }
-        public string? takerVol30Day { get; set; }      // USDT
-        public string? makerVol30Day { get; set; }      // USDT
-        public string? tradeVol30Day { get; set; }      // USDT
-        public string? depositAmount30Day { get; set; } // USDT
-        public string? takerVol365Day { get; set; }     // USDT
-        public string? makerVol365Day { get; set; }     // USDT
-        public string? tradeVol365Day { get; set; }     // USDT
-        public string? depositAmount365Day { get; set; }// USDT
-    }
+        [JsonProperty("userId")]
+        public string? UserId { get; set; }
 
+        [JsonProperty("registerTime")]
+        public string? RegisterTime { get; set; }
+
+        [JsonProperty("source")]
+        public string? Source { get; set; }
+
+        [JsonProperty("remarks")]
+        public string? Remarks { get; set; }
+
+        [JsonProperty("isKyc")]
+        public bool? IsKyc { get; set; }
+
+        [JsonProperty("takerVol30Day")]
+        public string? TakerVol30Day { get; set; }
+
+        [JsonProperty("makerVol30Day")]
+        public string? MakerVol30Day { get; set; }
+
+        [JsonProperty("tradeVol30Day")]
+        public string? TradeVol30Day { get; set; }
+
+        [JsonProperty("depositAmount30Day")]
+        public string? DepositAmount30Day { get; set; }
+
+        [JsonProperty("takerVol365Day")]
+        public string? TakerVol365Day { get; set; }
+
+        [JsonProperty("makerVol365Day")]
+        public string? MakerVol365Day { get; set; }
+
+        [JsonProperty("tradeVol365Day")]
+        public string? TradeVol365Day { get; set; }
+
+        [JsonProperty("depositAmount365Day")]
+        public string? DepositAmount365Day { get; set; }
+
+        [JsonProperty("takerVol")]
+        public string? TakerVol { get; set; }
+
+        [JsonProperty("makerVol")]
+        public string? MakerVol { get; set; }
+
+        [JsonProperty("tradeVol")]
+        public string? TradeVol { get; set; }
+
+        [JsonProperty("startDate")]
+        public string? StartDate { get; set; }
+
+        [JsonProperty("endDate")]
+        public string? EndDate { get; set; }
+
+        [JsonProperty("tradfiTradeVol")]
+        public string? TradfiTradeVol { get; set; }
+
+        [JsonProperty("tradfiTradeVol30Day")]
+        public string? TradfiTradeVol30Day { get; set; }
+
+        [JsonProperty("tradfiTradeVol365Day")]
+        public string? TradfiTradeVol365Day { get; set; }
+
+        [JsonProperty("commissionsVol")]
+        public Dictionary<string, string>? CommissionsVol { get; set; }
+
+        [JsonProperty("commissions30Day")]
+        public Dictionary<string, string>? Commissions30Day { get; set; }
+
+        [JsonProperty("commissions365Day")]
+        public Dictionary<string, string>? Commissions365Day { get; set; }
+    }
 }

--- a/Src/Common/Models/Asset/FiatConvertModels.cs
+++ b/Src/Common/Models/Asset/FiatConvertModels.cs
@@ -1,0 +1,172 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetFiatBalanceResult
+    {
+        [JsonProperty("totalBalance")]
+        public string? TotalBalance { get; set; }
+
+        [JsonProperty("balance")]
+        public string? Balance { get; set; }
+
+        [JsonProperty("frozenBalance")]
+        public string? FrozenBalance { get; set; }
+
+        [JsonProperty("currency")]
+        public string? Currency { get; set; }
+    }
+
+    public class GetFiatTradingPairListResult
+    {
+        [JsonProperty("fiats")]
+        public List<FiatCoinEntry>? Fiats { get; set; }
+
+        [JsonProperty("cryptos")]
+        public List<FiatCoinEntry>? Cryptos { get; set; }
+    }
+
+    public class FiatCoinEntry
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("fullName")]
+        public string? FullName { get; set; }
+
+        [JsonProperty("icon")]
+        public string? Icon { get; set; }
+
+        [JsonProperty("iconNight")]
+        public string? IconNight { get; set; }
+
+        [JsonProperty("precision")]
+        public int? Precision { get; set; }
+
+        [JsonProperty("disable")]
+        public bool? Disable { get; set; }
+
+        [JsonProperty("singleFromMinLimit")]
+        public string? SingleFromMinLimit { get; set; }
+
+        [JsonProperty("singleFromMaxLimit")]
+        public string? SingleFromMaxLimit { get; set; }
+    }
+
+    public class RequestFiatQuoteResult
+    {
+        [JsonProperty("quoteTaxId")]
+        public string? QuoteTxId { get; set; }
+
+        [JsonProperty("quoteTxId")]
+        private string? QuoteTxIdAlias { set => QuoteTxId ??= value; }
+
+        [JsonProperty("exchangeRate")]
+        public string? ExchangeRate { get; set; }
+
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("fromCoinType")]
+        public string? FromCoinType { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toCoinType")]
+        public string? ToCoinType { get; set; }
+
+        [JsonProperty("fromAmount")]
+        public string? FromAmount { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("expireTime")]
+        public string? ExpireTime { get; set; }
+
+        [JsonProperty("expiredTime")]
+        private string? ExpireTimeAlias { set => ExpireTime ??= value; }
+    }
+
+    public class ConfirmFiatQuoteResult
+    {
+        [JsonProperty("tradeNo")]
+        public string? TradeNo { get; set; }
+
+        [JsonProperty("merchantRequestId")]
+        public string? MerchantRequestId { get; set; }
+    }
+
+    public class GetFiatConvertStatusResult
+    {
+        [JsonProperty("tradeNo")]
+        public string? TradeNo { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("quoteTaxId")]
+        public string? QuoteTxId { get; set; }
+
+        [JsonProperty("quoteTxId")]
+        private string? QuoteTxIdAlias { set => QuoteTxId ??= value; }
+
+        [JsonProperty("exchangeRate")]
+        public string? ExchangeRate { get; set; }
+
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("fromCoinType")]
+        public string? FromCoinType { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toCoinType")]
+        public string? ToCoinType { get; set; }
+
+        [JsonProperty("fromAmount")]
+        public string? FromAmount { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("subUserId")]
+        public string? SubUserId { get; set; }
+    }
+
+    public class GetFiatReferencePriceResult
+    {
+        [JsonProperty("symbol")]
+        public string? Symbol { get; set; }
+
+        [JsonProperty("fiat")]
+        public string? Fiat { get; set; }
+
+        [JsonProperty("crypto")]
+        public string? Crypto { get; set; }
+
+        [JsonProperty("timestamp")]
+        public string? Timestamp { get; set; }
+
+        [JsonProperty("buys")]
+        public List<ReferencePriceQuote>? Buys { get; set; }
+
+        [JsonProperty("sells")]
+        public List<ReferencePriceQuote>? Sells { get; set; }
+    }
+
+    public class ReferencePriceQuote
+    {
+        [JsonProperty("unitPrice")]
+        public string? UnitPrice { get; set; }
+
+        [JsonProperty("paymentMethod")]
+        public string? PaymentMethod { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/GetAllowedDepositCoinInfoResult.cs
+++ b/Src/Common/Models/Asset/GetAllowedDepositCoinInfoResult.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetAllowedDepositCoinInfoResult
+    {
+        [JsonProperty("rows")]
+        public List<AllowedDepositCoinInfo>? Rows { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class AllowedDepositCoinInfo
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("chain")]
+        public string? Chain { get; set; }
+
+        [JsonProperty("chainType")]
+        public string? ChainType { get; set; }
+
+        [JsonProperty("confirmation")]
+        public string? Confirmation { get; set; }
+
+        [JsonProperty("safeConfirmNumber")]
+        public string? SafeConfirmNumber { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/GetCoinExchangeRecordsResult.cs
+++ b/Src/Common/Models/Asset/GetCoinExchangeRecordsResult.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetCoinExchangeRecordsResult
+    {
+        [JsonProperty("orderBody")]
+        public List<CoinExchangeRecord>? OrderBody { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class CoinExchangeRecord
+    {
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("fromAmount")]
+        public string? FromAmount { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("exchangeRate")]
+        public string? ExchangeRate { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+
+        [JsonProperty("exchangeTxId")]
+        public string? ExchangeTxId { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/GetUsdcSettlementResult.cs
+++ b/Src/Common/Models/Asset/GetUsdcSettlementResult.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetUsdcSettlementResult
+    {
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("list")]
+        public List<UsdcSettlementEntry>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class UsdcSettlementEntry
+    {
+        [JsonProperty("symbol")]
+        public string? Symbol { get; set; }
+
+        [JsonProperty("side")]
+        public string? Side { get; set; }
+
+        [JsonProperty("size")]
+        public string? Size { get; set; }
+
+        [JsonProperty("sessionAvgPrice")]
+        public string? SessionAvgPrice { get; set; }
+
+        [JsonProperty("markPrice")]
+        public string? MarkPrice { get; set; }
+
+        [JsonProperty("realisedPnl")]
+        public string? RealisedPnl { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/PortfolioMarginModels.cs
+++ b/Src/Common/Models/Asset/PortfolioMarginModels.cs
@@ -1,0 +1,181 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetPortfolioMarginInfoResult
+    {
+        [JsonProperty("wallet")]
+        public PortfolioMarginWallet? Wallet { get; set; }
+
+        [JsonProperty("assetPnlRange")]
+        public List<PortfolioMarginAssetPnlRange>? AssetPnlRange { get; set; }
+    }
+
+    public class PortfolioMarginWallet
+    {
+        [JsonProperty("equity")]
+        public string? Equity { get; set; }
+
+        [JsonProperty("cashBalance")]
+        public string? CashBalance { get; set; }
+
+        [JsonProperty("marginBalance")]
+        public string? MarginBalance { get; set; }
+
+        [JsonProperty("availableBalance")]
+        public string? AvailableBalance { get; set; }
+
+        [JsonProperty("accountIM")]
+        public string? AccountIm { get; set; }
+
+        [JsonProperty("accountMM")]
+        public string? AccountMm { get; set; }
+
+        [JsonProperty("accountMMRate")]
+        public string? AccountMmRate { get; set; }
+
+        [JsonProperty("accountIMRate")]
+        public string? AccountImRate { get; set; }
+    }
+
+    public class PortfolioMarginAssetPnlRange
+    {
+        [JsonProperty("baseCoin")]
+        public string? BaseCoin { get; set; }
+
+        [JsonProperty("totalPnlRanges")]
+        public Dictionary<string, PortfolioMarginPnlRangeGroup>? TotalPnlRanges { get; set; }
+
+        [JsonProperty("perpPositionPnlRanges")]
+        public List<PortfolioMarginPositionPnlRange>? PerpPositionPnlRanges { get; set; }
+
+        [JsonProperty("optionExpiryDatePnlRanges")]
+        public List<PortfolioMarginOptionExpiryPnlRange>? OptionExpiryDatePnlRanges { get; set; }
+
+        [JsonProperty("contingency")]
+        public PortfolioMarginContingency? Contingency { get; set; }
+
+        [JsonProperty("asset")]
+        public PortfolioMarginAssetInfo? Asset { get; set; }
+
+        [JsonProperty("maxLossPriceMove")]
+        public string? MaxLossPriceMove { get; set; }
+
+        [JsonProperty("maxLossIvShock")]
+        public string? MaxLossIvShock { get; set; }
+
+        [JsonProperty("totalClosePzFee")]
+        public string? TotalClosePzFee { get; set; }
+
+        [JsonProperty("spotHedgeInfo")]
+        public PortfolioMarginSpotHedgeInfo? SpotHedgeInfo { get; set; }
+
+        [JsonProperty("maxLossIvShockList")]
+        public List<string>? MaxLossIvShockList { get; set; }
+    }
+
+    public class PortfolioMarginPnlRangeGroup
+    {
+        [JsonProperty("pnlRanges")]
+        public List<PortfolioMarginPnlRange>? PnlRanges { get; set; }
+    }
+
+    public class PortfolioMarginPnlRange
+    {
+        [JsonProperty("priceScale")]
+        public string? PriceScale { get; set; }
+
+        [JsonProperty("pnls")]
+        public List<string>? Pnls { get; set; }
+    }
+
+    public class PortfolioMarginPositionPnlRange
+    {
+        [JsonProperty("symbolName")]
+        public string? SymbolName { get; set; }
+
+        [JsonProperty("position")]
+        public string? Position { get; set; }
+
+        [JsonProperty("pnlRanges")]
+        public List<PortfolioMarginPnlRange>? PnlRanges { get; set; }
+
+        [JsonProperty("sessionAvgPrice")]
+        public string? SessionAvgPrice { get; set; }
+
+        [JsonProperty("markPrice")]
+        public string? MarkPrice { get; set; }
+
+        [JsonProperty("orderSize")]
+        public string? OrderSize { get; set; }
+
+        [JsonProperty("contractType")]
+        public int? ContractType { get; set; }
+
+        [JsonProperty("settleCoin")]
+        public string? SettleCoin { get; set; }
+
+        [JsonProperty("symbolAlias")]
+        public string? SymbolAlias { get; set; }
+    }
+
+    public class PortfolioMarginOptionExpiryPnlRange
+    {
+        [JsonProperty("expiryDateRepresentation")]
+        public string? ExpiryDateRepresentation { get; set; }
+
+        [JsonProperty("pnlRanges")]
+        public List<PortfolioMarginPnlRange>? PnlRanges { get; set; }
+
+        [JsonProperty("optionPositionPnlRanges")]
+        public List<PortfolioMarginPositionPnlRange>? OptionPositionPnlRanges { get; set; }
+    }
+
+    public class PortfolioMarginContingency
+    {
+        [JsonProperty("optionContingency")]
+        public string? OptionContingency { get; set; }
+
+        [JsonProperty("futureDeltaContingency")]
+        public string? FutureDeltaContingency { get; set; }
+
+        [JsonProperty("optionVegaContingency")]
+        public string? OptionVegaContingency { get; set; }
+
+        [JsonProperty("contingencyComponents")]
+        public string? ContingencyComponents { get; set; }
+
+        [JsonProperty("usdtUsdcContingency")]
+        public string? UsdtUsdcContingency { get; set; }
+
+        [JsonProperty("futureContingency")]
+        public string? FutureContingency { get; set; }
+    }
+
+    public class PortfolioMarginAssetInfo
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("assetIM")]
+        public string? AssetIm { get; set; }
+
+        [JsonProperty("assetMM")]
+        public string? AssetMm { get; set; }
+    }
+
+    public class PortfolioMarginSpotHedgeInfo
+    {
+        [JsonProperty("hedgeSpotSize")]
+        public string? HedgeSpotSize { get; set; }
+
+        [JsonProperty("walletBalance")]
+        public string? WalletBalance { get; set; }
+
+        [JsonProperty("usdIndexPrice")]
+        public string? UsdIndexPrice { get; set; }
+
+        [JsonProperty("pnlRanges")]
+        public List<PortfolioMarginPnlRange>? PnlRanges { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/SmallBalanceConvertModels.cs
+++ b/Src/Common/Models/Asset/SmallBalanceConvertModels.cs
@@ -1,0 +1,193 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetSmallBalanceCoinsResult
+    {
+        [JsonProperty("smallAssetCoins")]
+        public List<SmallBalanceCoinEntry>? SmallAssetCoins { get; set; }
+
+        [JsonProperty("supportToCoins")]
+        public List<string>? SupportToCoins { get; set; }
+    }
+
+    public class SmallBalanceCoinEntry
+    {
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("supportConvert")]
+        public int? SupportConvert { get; set; }
+
+        [JsonProperty("availableBalance")]
+        public string? AvailableBalance { get; set; }
+
+        [JsonProperty("baseValue")]
+        public string? BaseValue { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("exchangeRate")]
+        public string? ExchangeRate { get; set; }
+
+        [JsonProperty("feeInfo")]
+        public FeeDetail? FeeInfo { get; set; }
+
+        [JsonProperty("taxFeeInfo")]
+        public TaxFeeInfo? TaxFeeInfo { get; set; }
+    }
+
+    public class RequestSmallBalanceQuoteResult
+    {
+        [JsonProperty("quoteId")]
+        public string? QuoteId { get; set; }
+
+        [JsonProperty("result")]
+        public SmallBalanceQuoteDetail? Result { get; set; }
+    }
+
+    public class SmallBalanceQuoteDetail
+    {
+        [JsonProperty("quoteCreateTime")]
+        public string? QuoteCreateTime { get; set; }
+
+        [JsonProperty("quoteExpireTime")]
+        public string? QuoteExpireTime { get; set; }
+
+        [JsonProperty("exchangeCoins")]
+        public List<SmallBalanceCoinEntry>? ExchangeCoins { get; set; }
+
+        [JsonProperty("totalFeeInfo")]
+        public FeeDetail? TotalFeeInfo { get; set; }
+
+        [JsonProperty("totalTaxFeeInfo")]
+        public TaxFeeInfo? TotalTaxFeeInfo { get; set; }
+    }
+
+    public class ConfirmSmallBalanceQuoteResult
+    {
+        [JsonProperty("quoteId")]
+        public string? QuoteId { get; set; }
+
+        [JsonProperty("exchangeTxId")]
+        public string? ExchangeTxId { get; set; }
+
+        [JsonProperty("submitTime")]
+        public string? SubmitTime { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("msg")]
+        public string? Msg { get; set; }
+    }
+
+    public class GetSmallBalanceExchangeHistoryResult
+    {
+        [JsonProperty("cursor")]
+        public string? Cursor { get; set; }
+
+        [JsonProperty("size")]
+        public string? Size { get; set; }
+
+        [JsonProperty("lastPage")]
+        public string? LastPage { get; set; }
+
+        [JsonProperty("totalCount")]
+        public string? TotalCount { get; set; }
+
+        [JsonProperty("records")]
+        public List<SmallBalanceExchangeHistoryRecord>? Records { get; set; }
+    }
+
+    public class SmallBalanceExchangeHistoryRecord
+    {
+        [JsonProperty("accountType")]
+        public string? AccountType { get; set; }
+
+        [JsonProperty("exchangeTxId")]
+        public string? ExchangeTxId { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("subRecords")]
+        public List<SmallBalanceSubRecord>? SubRecords { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("exchangeSource")]
+        public string? ExchangeSource { get; set; }
+
+        [JsonProperty("feeCoin")]
+        public string? FeeCoin { get; set; }
+
+        [JsonProperty("totalFeeAmount")]
+        public string? TotalFeeAmount { get; set; }
+
+        [JsonProperty("totalTaxFeeInfo")]
+        public TaxFeeInfo? TotalTaxFeeInfo { get; set; }
+    }
+
+    public class SmallBalanceSubRecord
+    {
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("fromAmount")]
+        public string? FromAmount { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("feeCoin")]
+        public string? FeeCoin { get; set; }
+
+        [JsonProperty("feeAmount")]
+        public string? FeeAmount { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("taxFeeInfo")]
+        public TaxFeeInfo? TaxFeeInfo { get; set; }
+    }
+
+    public class FeeDetail
+    {
+        [JsonProperty("feeCoin")]
+        public string? FeeCoin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("feeRate")]
+        public string? FeeRate { get; set; }
+    }
+
+    public class TaxFeeInfo
+    {
+        [JsonProperty("totalAmount")]
+        public string? TotalAmount { get; set; }
+
+        [JsonProperty("feeCoin")]
+        public string? FeeCoin { get; set; }
+
+        [JsonProperty("taxFeeItems")]
+        public List<object>? TaxFeeItems { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/SummaryModels.cs
+++ b/Src/Common/Models/Asset/SummaryModels.cs
@@ -1,0 +1,154 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetFundingHistoryResult
+    {
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+
+        [JsonProperty("list")]
+        public List<FundingHistoryEntry>? List { get; set; }
+    }
+
+    public class FundingHistoryEntry
+    {
+        [JsonProperty("memberId")]
+        public string? MemberId { get; set; }
+
+        [JsonProperty("currency")]
+        public string? Currency { get; set; }
+
+        [JsonProperty("ioDirection")]
+        public string? IoDirection { get; set; }
+
+        [JsonProperty("txnAmt")]
+        public string? TxnAmt { get; set; }
+
+        [JsonProperty("afterAmt")]
+        public string? AfterAmt { get; set; }
+
+        [JsonProperty("createTime")]
+        public string? CreateTime { get; set; }
+
+        [JsonProperty("showBusiType")]
+        public string? ShowBusiType { get; set; }
+
+        [JsonProperty("showBusiTypeEn")]
+        public string? ShowBusiTypeEn { get; set; }
+
+        [JsonProperty("description")]
+        public string? Description { get; set; }
+
+        [JsonProperty("descriptionEn")]
+        public string? DescriptionEn { get; set; }
+    }
+
+    public class GetTotalMembersAssetsResult
+    {
+        [JsonProperty("total")]
+        public string? Total { get; set; }
+
+        [JsonProperty("quoteTotal")]
+        public string? QuoteTotal { get; set; }
+
+        [JsonProperty("stat")]
+        public int? Stat { get; set; }
+
+        [JsonProperty("list")]
+        public List<MemberAssetEntry>? List { get; set; }
+    }
+
+    public class MemberAssetEntry
+    {
+        [JsonProperty("uid")]
+        public long? Uid { get; set; }
+
+        [JsonProperty("isM")]
+        public bool? IsMaster { get; set; }
+
+        [JsonProperty("type")]
+        public int? Type { get; set; }
+
+        [JsonProperty("stat")]
+        public int? Stat { get; set; }
+
+        [JsonProperty("origb")]
+        public string? Origb { get; set; }
+
+        [JsonProperty("quoteb")]
+        public string? Quoteb { get; set; }
+
+        [JsonProperty("items")]
+        public List<MemberAssetItem>? Items { get; set; }
+    }
+
+    public class MemberAssetItem
+    {
+        [JsonProperty("type")]
+        public string? Type { get; set; }
+
+        [JsonProperty("origb")]
+        public string? Origb { get; set; }
+
+        [JsonProperty("quoteb")]
+        public string? Quoteb { get; set; }
+
+        [JsonProperty("stat")]
+        public int? Stat { get; set; }
+    }
+
+    public class GetAssetOverviewResult
+    {
+        [JsonProperty("totalEquity")]
+        public string? TotalEquity { get; set; }
+
+        [JsonProperty("list")]
+        public List<AssetOverviewEntry>? List { get; set; }
+    }
+
+    public class AssetOverviewEntry
+    {
+        [JsonProperty("accountType")]
+        public string? AccountType { get; set; }
+
+        [JsonProperty("totalEquity")]
+        public string? TotalEquity { get; set; }
+
+        [JsonProperty("valuationCurrency")]
+        public string? ValuationCurrency { get; set; }
+
+        [JsonProperty("snapshotTime")]
+        public string? SnapshotTime { get; set; }
+
+        [JsonProperty("coinDetail")]
+        public List<AssetOverviewCoinDetail>? CoinDetail { get; set; }
+
+        [JsonProperty("categories")]
+        public List<AssetOverviewCategory>? Categories { get; set; }
+    }
+
+    public class AssetOverviewCategory
+    {
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("equity")]
+        public string? Equity { get; set; }
+
+        [JsonProperty("coinDetail")]
+        public List<AssetOverviewCoinDetail>? CoinDetail { get; set; }
+    }
+
+    public class AssetOverviewCoinDetail
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("equity")]
+        public string? Equity { get; set; }
+
+        [JsonProperty("extMap")]
+        public Dictionary<string, string>? ExtMap { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/TransferModels.cs
+++ b/Src/Common/Models/Asset/TransferModels.cs
@@ -1,0 +1,58 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetTransferableCoinResult
+    {
+        [JsonProperty("list")]
+        public List<string>? List { get; set; }
+    }
+
+    public class CreateTransferResult
+    {
+        [JsonProperty("transferId")]
+        public string? TransferId { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+    }
+
+    public class GetTransferRecordsResult
+    {
+        [JsonProperty("list")]
+        public List<TransferRecordItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class TransferRecordItem
+    {
+        [JsonProperty("transferId")]
+        public string? TransferId { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("fromMemberId")]
+        public string? FromMemberId { get; set; }
+
+        [JsonProperty("toMemberId")]
+        public string? ToMemberId { get; set; }
+
+        [JsonProperty("fromAccountType")]
+        public string? FromAccountType { get; set; }
+
+        [JsonProperty("toAccountType")]
+        public string? ToAccountType { get; set; }
+
+        [JsonProperty("timestamp")]
+        public string? Timestamp { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+    }
+}

--- a/Src/Common/Models/Asset/WithdrawalAddressModels.cs
+++ b/Src/Common/Models/Asset/WithdrawalAddressModels.cs
@@ -1,0 +1,43 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Asset
+{
+    public class GetWithdrawalAddressListResult
+    {
+        [JsonProperty("rows")]
+        public List<WithdrawalAddressEntry>? Rows { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class WithdrawalAddressEntry
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("chain")]
+        public string? Chain { get; set; }
+
+        [JsonProperty("address")]
+        public string? Address { get; set; }
+
+        [JsonProperty("tag")]
+        public string? Tag { get; set; }
+
+        [JsonProperty("remark")]
+        public string? Remark { get; set; }
+
+        [JsonProperty("status")]
+        public int? Status { get; set; }
+
+        [JsonProperty("addressType")]
+        public int? AddressType { get; set; }
+
+        [JsonProperty("verified")]
+        public int? Verified { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+    }
+}

--- a/Src/Common/Models/Broker/BrokerAccountModels.cs
+++ b/Src/Common/Models/Broker/BrokerAccountModels.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Broker
+{
+    public class GetBrokerAccountInfoResult
+    {
+        [JsonProperty("subAcctQty")]
+        public string? SubAcctQty { get; set; }
+
+        [JsonProperty("maxSubAcctQty")]
+        public string? MaxSubAcctQty { get; set; }
+
+        [JsonProperty("baseFeeRebateRate")]
+        public BrokerRebateRate? BaseFeeRebateRate { get; set; }
+
+        [JsonProperty("markupFeeRebateRate")]
+        public BrokerRebateRate? MarkupFeeRebateRate { get; set; }
+
+        [JsonProperty("ts")]
+        public string? Ts { get; set; }
+    }
+
+    public class BrokerRebateRate
+    {
+        [JsonProperty("spot")]
+        public string? Spot { get; set; }
+
+        [JsonProperty("derivatives")]
+        public string? Derivatives { get; set; }
+
+        [JsonProperty("convert")]
+        public string? Convert { get; set; }
+    }
+}

--- a/Src/Common/Models/Broker/BrokerDepositModels.cs
+++ b/Src/Common/Models/Broker/BrokerDepositModels.cs
@@ -1,0 +1,73 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Broker
+{
+    public class GetBrokerSubMemberDepositRecordsResult
+    {
+        [JsonProperty("rows")]
+        public List<BrokerSubMemberDepositRecord>? Rows { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class BrokerSubMemberDepositRecord
+    {
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        [JsonProperty("subMemberId")]
+        public string? SubMemberId { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("chain")]
+        public string? Chain { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("txID")]
+        public string? TxId { get; set; }
+
+        [JsonProperty("status")]
+        public int? Status { get; set; }
+
+        [JsonProperty("toAddress")]
+        public string? ToAddress { get; set; }
+
+        [JsonProperty("tag")]
+        public string? Tag { get; set; }
+
+        [JsonProperty("depositFee")]
+        public string? DepositFee { get; set; }
+
+        [JsonProperty("successAt")]
+        public string? SuccessAt { get; set; }
+
+        [JsonProperty("confirmations")]
+        public string? Confirmations { get; set; }
+
+        [JsonProperty("txIndex")]
+        public string? TxIndex { get; set; }
+
+        [JsonProperty("blockHash")]
+        public string? BlockHash { get; set; }
+
+        [JsonProperty("batchReleaseLimit")]
+        public string? BatchReleaseLimit { get; set; }
+
+        [JsonProperty("depositType")]
+        public string? DepositType { get; set; }
+
+        [JsonProperty("fromAddress")]
+        public string? FromAddress { get; set; }
+
+        [JsonProperty("taxDepositRecordsId")]
+        public string? TaxDepositRecordsId { get; set; }
+
+        [JsonProperty("taxStatus")]
+        public int? TaxStatus { get; set; }
+    }
+}

--- a/Src/Common/Models/Broker/BrokerEarningModels.cs
+++ b/Src/Common/Models/Broker/BrokerEarningModels.cs
@@ -1,0 +1,76 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Broker
+{
+    public class GetBrokerEarningResult
+    {
+        [JsonProperty("totalEarningCat")]
+        public BrokerEarningCategorySummary? TotalEarningCat { get; set; }
+
+        [JsonProperty("details")]
+        public List<BrokerEarningDetail>? Details { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class BrokerEarningCategorySummary
+    {
+        [JsonProperty("spot")]
+        public List<BrokerCoinEarning>? Spot { get; set; }
+
+        [JsonProperty("derivatives")]
+        public List<BrokerCoinEarning>? Derivatives { get; set; }
+
+        [JsonProperty("options")]
+        public List<BrokerCoinEarning>? Options { get; set; }
+
+        [JsonProperty("convert")]
+        public List<BrokerCoinEarning>? Convert { get; set; }
+
+        [JsonProperty("total")]
+        public List<BrokerCoinEarning>? Total { get; set; }
+    }
+
+    public class BrokerCoinEarning
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("earning")]
+        public string? Earning { get; set; }
+    }
+
+    public class BrokerEarningDetail
+    {
+        [JsonProperty("userId")]
+        public string? UserId { get; set; }
+
+        [JsonProperty("bizType")]
+        public string? BizType { get; set; }
+
+        [JsonProperty("symbol")]
+        public string? Symbol { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("earning")]
+        public string? Earning { get; set; }
+
+        [JsonProperty("markupEarning")]
+        public string? MarkupEarning { get; set; }
+
+        [JsonProperty("baseFeeEarning")]
+        public string? BaseFeeEarning { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("execId")]
+        public string? ExecId { get; set; }
+
+        [JsonProperty("execTime")]
+        public string? ExecTime { get; set; }
+    }
+}

--- a/Src/Common/Models/Broker/BrokerRateLimitModels.cs
+++ b/Src/Common/Models/Broker/BrokerRateLimitModels.cs
@@ -1,0 +1,82 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Broker
+{
+    public class GetBrokerRateLimitAllResult
+    {
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+
+        [JsonProperty("list")]
+        public List<BrokerRateLimitEntry>? List { get; set; }
+    }
+
+    public class BrokerRateLimitEntry
+    {
+        [JsonProperty("uids")]
+        public string? Uids { get; set; }
+
+        [JsonProperty("bizType")]
+        public string? BizType { get; set; }
+
+        [JsonProperty("rate")]
+        public int? Rate { get; set; }
+    }
+
+    public class GetBrokerRateLimitCapResult
+    {
+        [JsonProperty("list")]
+        public List<BrokerRateLimitCapEntry>? List { get; set; }
+    }
+
+    public class BrokerRateLimitCapEntry
+    {
+        [JsonProperty("bizType")]
+        public string? BizType { get; set; }
+
+        [JsonProperty("totalRate")]
+        public string? TotalRate { get; set; }
+
+        [JsonProperty("ebCap")]
+        public string? EbCap { get; set; }
+
+        [JsonProperty("uidCap")]
+        public string? UidCap { get; set; }
+    }
+
+    public class BrokerRateLimitRequestItem
+    {
+        [JsonProperty("uids")]
+        public string? Uids { get; set; }
+
+        [JsonProperty("bizType")]
+        public string? BizType { get; set; }
+
+        [JsonProperty("rate")]
+        public int? Rate { get; set; }
+    }
+
+    public class SetBrokerRateLimitResult
+    {
+        [JsonProperty("result")]
+        public List<SetBrokerRateLimitResultItem>? Result { get; set; }
+    }
+
+    public class SetBrokerRateLimitResultItem
+    {
+        [JsonProperty("uids")]
+        public string? Uids { get; set; }
+
+        [JsonProperty("bizType")]
+        public string? BizType { get; set; }
+
+        [JsonProperty("rate")]
+        public int? Rate { get; set; }
+
+        [JsonProperty("success")]
+        public bool? Success { get; set; }
+
+        [JsonProperty("msg")]
+        public string? Msg { get; set; }
+    }
+}

--- a/Src/Common/Models/Broker/BrokerVoucherModels.cs
+++ b/Src/Common/Models/Broker/BrokerVoucherModels.cs
@@ -1,0 +1,65 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Broker
+{
+    public class GetBrokerVoucherSpecResult
+    {
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amountUnit")]
+        public string? AmountUnit { get; set; }
+
+        [JsonProperty("productLine")]
+        public string? ProductLine { get; set; }
+
+        [JsonProperty("subProductLine")]
+        public string? SubProductLine { get; set; }
+
+        [JsonProperty("totalAmount")]
+        public string? TotalAmount { get; set; }
+
+        [JsonProperty("usedAmount")]
+        public string? UsedAmount { get; set; }
+    }
+
+    public class IssueBrokerVoucherResult
+    {
+    }
+
+    public class GetIssuedBrokerVoucherResult
+    {
+        [JsonProperty("accountId")]
+        public string? AccountId { get; set; }
+
+        [JsonProperty("awardId")]
+        public string? AwardId { get; set; }
+
+        [JsonProperty("specCode")]
+        public string? SpecCode { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("isClaimed")]
+        public bool? IsClaimed { get; set; }
+
+        [JsonProperty("startAt")]
+        public string? StartAt { get; set; }
+
+        [JsonProperty("endAt")]
+        public string? EndAt { get; set; }
+
+        [JsonProperty("effectiveAt")]
+        public string? EffectiveAt { get; set; }
+
+        [JsonProperty("ineffectiveAt")]
+        public string? IneffectiveAt { get; set; }
+
+        [JsonProperty("usedAmount")]
+        public string? UsedAmount { get; set; }
+    }
+}

--- a/Src/Common/Models/CryptoLoan/CryptoLoanModels.cs
+++ b/Src/Common/Models/CryptoLoan/CryptoLoanModels.cs
@@ -1,0 +1,330 @@
+using System.Collections.Generic;
+
+namespace bybit.net.api.Models.CryptoLoan
+{
+    public class CryptoLoanCollateralItem
+    {
+        public string? currency { get; set; }
+        public string? amount { get; set; }
+    }
+
+    public class MaxLoanCollateralItem
+    {
+        public string? ccy { get; set; }
+        public string? amount { get; set; }
+    }
+
+    public class CryptoLoanOrderIdResult
+    {
+        public string? orderId { get; set; }
+    }
+
+    public class CryptoLoanRepayIdResult
+    {
+        public string? repayId { get; set; }
+    }
+
+    public class GetBorrowableCoinsResult
+    {
+        public List<BorrowableCoinInfo>? list { get; set; }
+    }
+
+    public class BorrowableCoinInfo
+    {
+        public string? currency { get; set; }
+        public bool? fixedBorrowable { get; set; }
+        public int? fixedBorrowingAccuracy { get; set; }
+        public bool? flexibleBorrowable { get; set; }
+        public int? flexibleBorrowingAccuracy { get; set; }
+        public string? maxBorrowingAmount { get; set; }
+        public string? minFixedBorrowingAmount { get; set; }
+        public string? minFlexibleBorrowingAmount { get; set; }
+        public string? vipLevel { get; set; }
+        public string? flexibleAnnualizedInterestRate { get; set; }
+        public string? annualizedInterestRate7D { get; set; }
+        public string? annualizedInterestRate14D { get; set; }
+        public string? annualizedInterestRate30D { get; set; }
+        public string? annualizedInterestRate60D { get; set; }
+        public string? annualizedInterestRate90D { get; set; }
+        public string? annualizedInterestRate180D { get; set; }
+    }
+
+    public class GetCollateralCoinsResult
+    {
+        public List<CollateralRatioConfig>? collateralRatioConfigList { get; set; }
+        public List<CurrencyLiquidationInfo>? currencyLiquidationList { get; set; }
+    }
+
+    public class CollateralRatioConfig
+    {
+        public List<CollateralRatioInfo>? collateralRatioList { get; set; }
+        public string? currencies { get; set; }
+    }
+
+    public class CollateralRatioInfo
+    {
+        public string? collateralRatio { get; set; }
+        public string? maxValue { get; set; }
+        public string? minValue { get; set; }
+    }
+
+    public class CurrencyLiquidationInfo
+    {
+        public string? currency { get; set; }
+        public int? liquidationOrder { get; set; }
+    }
+
+    public class GetMaxAllowedCollateralReductionAmountResult
+    {
+        public string? maxCollateralAmount { get; set; }
+    }
+
+    public class GetMaxLoanAmountResult
+    {
+        public string? currency { get; set; }
+        public string? maxLoan { get; set; }
+        public string? notionalUsd { get; set; }
+        public string? remainingQuota { get; set; }
+    }
+
+    public class AdjustCollateralAmountResult
+    {
+        public long? adjustId { get; set; }
+    }
+
+    public class GetCollateralAdjustmentHistoryResult
+    {
+        public List<CollateralAdjustmentHistoryItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class CollateralAdjustmentHistoryItem
+    {
+        public string? collateralCurrency { get; set; }
+        public string? amount { get; set; }
+        public long? adjustId { get; set; }
+        public long? adjustTime { get; set; }
+        public string? preLTV { get; set; }
+        public string? afterLTV { get; set; }
+        public int? direction { get; set; }
+        public int? status { get; set; }
+    }
+
+    public class GetCryptoLoanPositionResult
+    {
+        public List<CryptoLoanBorrowPosition>? borrowList { get; set; }
+        public List<CryptoLoanCollateralPosition>? collateralList { get; set; }
+        public string? ltv { get; set; }
+        public List<CryptoLoanSupplyPosition>? supplyList { get; set; }
+        public string? totalCollateral { get; set; }
+        public string? totalDebt { get; set; }
+        public string? totalSupply { get; set; }
+    }
+
+    public class CryptoLoanBorrowPosition
+    {
+        public string? fixedTotalDebt { get; set; }
+        public string? fixedTotalDebtUSD { get; set; }
+        public string? flexibleHourlyInterestRate { get; set; }
+        public string? flexibleTotalDebt { get; set; }
+        public string? flexibleTotalDebtUSD { get; set; }
+        public string? loanCurrency { get; set; }
+    }
+
+    public class CryptoLoanCollateralPosition
+    {
+        public string? amount { get; set; }
+        public string? amountUSD { get; set; }
+        public string? currency { get; set; }
+    }
+
+    public class CryptoLoanSupplyPosition
+    {
+        public string? amount { get; set; }
+        public string? amountUSD { get; set; }
+        public string? currency { get; set; }
+    }
+
+    public class GetFlexibleLoansResult
+    {
+        public List<FlexibleLoanItem>? list { get; set; }
+    }
+
+    public class FlexibleLoanItem
+    {
+        public string? hourlyInterestRate { get; set; }
+        public string? loanCurrency { get; set; }
+        public string? totalDebt { get; set; }
+        public string? unpaidAmount { get; set; }
+        public string? unpaidInterest { get; set; }
+    }
+
+    public class GetFlexibleBorrowOrdersHistoryResult
+    {
+        public List<FlexibleBorrowOrderHistoryItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class FlexibleBorrowOrderHistoryItem
+    {
+        public long? borrowTime { get; set; }
+        public string? initialLoanAmount { get; set; }
+        public string? loanCurrency { get; set; }
+        public string? orderId { get; set; }
+        public int? status { get; set; }
+    }
+
+    public class GetFlexibleRepaymentOrdersHistoryResult
+    {
+        public List<FlexibleRepaymentOrderHistoryItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class FlexibleRepaymentOrderHistoryItem
+    {
+        public string? loanCurrency { get; set; }
+        public string? repayAmount { get; set; }
+        public string? repayId { get; set; }
+        public int? repayStatus { get; set; }
+        public long? repayTime { get; set; }
+        public int? repayType { get; set; }
+    }
+
+    public class GetFixedLoanMarketResult
+    {
+        public List<FixedLoanMarketItem>? list { get; set; }
+    }
+
+    public class FixedLoanMarketItem
+    {
+        public string? orderCurrency { get; set; }
+        public int? term { get; set; }
+        public string? annualRate { get; set; }
+        public string? qty { get; set; }
+    }
+
+    public class GetBorrowContractInfoFixedResult
+    {
+        public List<BorrowContractInfoFixedItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class BorrowContractInfoFixedItem
+    {
+        public string? annualRate { get; set; }
+        public string? autoRepay { get; set; }
+        public string? borrowCurrency { get; set; }
+        public string? borrowTime { get; set; }
+        public string? interestPaid { get; set; }
+        public string? loanId { get; set; }
+        public string? orderId { get; set; }
+        public string? repaymentTime { get; set; }
+        public string? residualPenaltyInterest { get; set; }
+        public string? residualPrincipal { get; set; }
+        public int? status { get; set; }
+        public string? term { get; set; }
+        public string? repayType { get; set; }
+    }
+
+    public class GetSupplyContractInfoFixedResult
+    {
+        public List<SupplyContractInfoFixedItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class SupplyContractInfoFixedItem
+    {
+        public string? annualRate { get; set; }
+        public string? supplyCurrency { get; set; }
+        public string? supplyTime { get; set; }
+        public string? supplyAmount { get; set; }
+        public string? interestPaid { get; set; }
+        public string? supplyId { get; set; }
+        public string? orderId { get; set; }
+        public string? redemptionTime { get; set; }
+        public string? penaltyInterest { get; set; }
+        public string? actualRedemptionTime { get; set; }
+        public int? status { get; set; }
+        public string? term { get; set; }
+    }
+
+    public class GetBorrowOrderInfoFixedResult
+    {
+        public List<FixedBorrowOrderInfoItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class FixedBorrowOrderInfoItem
+    {
+        public string? annualRate { get; set; }
+        public long? orderId { get; set; }
+        public string? orderTime { get; set; }
+        public string? filledQty { get; set; }
+        public string? orderQty { get; set; }
+        public string? orderCurrency { get; set; }
+        public int? state { get; set; }
+        public int? term { get; set; }
+        public string? repayType { get; set; }
+    }
+
+    public class GetSupplyOrderInfoFixedResult
+    {
+        public List<FixedSupplyOrderInfoItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class FixedSupplyOrderInfoItem
+    {
+        public string? annualRate { get; set; }
+        public long? orderId { get; set; }
+        public string? orderTime { get; set; }
+        public string? filledQty { get; set; }
+        public string? orderQty { get; set; }
+        public string? orderCurrency { get; set; }
+        public int? state { get; set; }
+        public int? term { get; set; }
+    }
+
+    public class GetRepaymentHistoryFixedResult
+    {
+        public List<FixedRepaymentHistoryItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class FixedRepaymentHistoryItem
+    {
+        public List<FixedRepaymentDetail>? details { get; set; }
+        public string? loanCurrency { get; set; }
+        public long? repayAmount { get; set; }
+        public string? repayId { get; set; }
+        public int? repayStatus { get; set; }
+        public long? repayTime { get; set; }
+        public int? repayType { get; set; }
+    }
+
+    public class FixedRepaymentDetail
+    {
+        public string? loanCurrency { get; set; }
+        public long? repayAmount { get; set; }
+        public string? loanId { get; set; }
+    }
+
+    public class GetRenewOrderInfoFixedResult
+    {
+        public List<RenewOrderInfoFixedItem>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class RenewOrderInfoFixedItem
+    {
+        public string? borrowCurrency { get; set; }
+        public string? amount { get; set; }
+        public int? autoRepay { get; set; }
+        public string? contractNo { get; set; }
+        public string? dueTime { get; set; }
+        public int? orderId { get; set; }
+        public string? loanId { get; set; }
+        public string? renewLoanNo { get; set; }
+        public string? time { get; set; }
+    }
+}

--- a/Src/Common/Models/Earn/EarnFixedTermModels.cs
+++ b/Src/Common/Models/Earn/EarnFixedTermModels.cs
@@ -1,0 +1,275 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Earn
+{
+    public class GetFixedTermProductInfoResult
+    {
+        [JsonProperty("list")]
+        public List<FixedTermProduct>? List { get; set; }
+    }
+
+    public class FixedTermProduct
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("duration")]
+        public string? Duration { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("tieredApyList")]
+        public List<FixedTermTieredApy>? TieredApyList { get; set; }
+
+        [JsonProperty("minStakeAmount")]
+        public string? MinStakeAmount { get; set; }
+
+        [JsonProperty("maxStakeAmount")]
+        public string? MaxStakeAmount { get; set; }
+
+        [JsonProperty("precision")]
+        public int? Precision { get; set; }
+
+        [JsonProperty("subscribeStartAt")]
+        public string? SubscribeStartAt { get; set; }
+
+        [JsonProperty("subscribeEndAt")]
+        public string? SubscribeEndAt { get; set; }
+
+        [JsonProperty("allowEarlyRedemption")]
+        public bool? AllowEarlyRedemption { get; set; }
+
+        [JsonProperty("earlyRedemptionApy")]
+        public string? EarlyRedemptionApy { get; set; }
+
+        [JsonProperty("redemptionLimitDuration")]
+        public string? RedemptionLimitDuration { get; set; }
+
+        [JsonProperty("allowAutoReinvest")]
+        public bool? AllowAutoReinvest { get; set; }
+
+        [JsonProperty("interestCoinApyList")]
+        public List<FixedTermInterestCoinApy>? InterestCoinApyList { get; set; }
+
+        [JsonProperty("isVip")]
+        public bool? IsVip { get; set; }
+
+        [JsonProperty("creditTime")]
+        public string? CreditTime { get; set; }
+
+        [JsonProperty("specialUserGroupRequired")]
+        public bool? SpecialUserGroupRequired { get; set; }
+
+        [JsonProperty("specialUserGroupInfo")]
+        public string? SpecialUserGroupInfo { get; set; }
+    }
+
+    public class FixedTermTieredApy
+    {
+        [JsonProperty("min")]
+        public string? Min { get; set; }
+
+        [JsonProperty("max")]
+        public string? Max { get; set; }
+
+        [JsonProperty("apy")]
+        public string? Apy { get; set; }
+    }
+
+    public class FixedTermInterestCoinApy
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("apy")]
+        public string? Apy { get; set; }
+
+        [JsonProperty("expectUnitEarning")]
+        public string? ExpectUnitEarning { get; set; }
+
+        [JsonProperty("currentPrice")]
+        public string? CurrentPrice { get; set; }
+    }
+
+    public class PlaceFixedTermOrderResult
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+    }
+
+    public class GetFixedTermOrderListResult
+    {
+        [JsonProperty("list")]
+        public List<FixedTermOrderItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class FixedTermOrderItem
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+
+        [JsonProperty("orderType")]
+        public string? OrderType { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("duration")]
+        public string? Duration { get; set; }
+
+        [JsonProperty("accountType")]
+        public string? AccountType { get; set; }
+
+        [JsonProperty("settlementTime")]
+        public string? SettlementTime { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("yieldInfoList")]
+        public List<FixedTermYieldInfo>? YieldInfoList { get; set; }
+    }
+
+    public class FixedTermYieldInfo
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("apy")]
+        public string? Apy { get; set; }
+    }
+
+    public class GetFixedTermPositionResult
+    {
+        [JsonProperty("list")]
+        public List<FixedTermPositionItem>? List { get; set; }
+    }
+
+    public class FixedTermPositionItem
+    {
+        [JsonProperty("positionId")]
+        public string? PositionId { get; set; }
+
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("effectiveAmount")]
+        public string? EffectiveAmount { get; set; }
+
+        [JsonProperty("duration")]
+        public string? Duration { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("settlementTime")]
+        public string? SettlementTime { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("earlyRedeemInfo")]
+        public FixedTermEarlyRedeemInfo? EarlyRedeemInfo { get; set; }
+
+        [JsonProperty("allowAutoReinvest")]
+        public bool? AllowAutoReinvest { get; set; }
+
+        [JsonProperty("autoReinvest")]
+        public string? AutoReinvest { get; set; }
+
+        [JsonProperty("interestCoinApyList")]
+        public List<FixedTermPositionInterestCoinApy>? InterestCoinApyList { get; set; }
+    }
+
+    public class FixedTermEarlyRedeemInfo
+    {
+        [JsonProperty("allowEarlyRedeem")]
+        public bool? AllowEarlyRedeem { get; set; }
+
+        [JsonProperty("earlyRedeemEarning")]
+        public string? EarlyRedeemEarning { get; set; }
+
+        [JsonProperty("returnCoin")]
+        public string? ReturnCoin { get; set; }
+
+        [JsonProperty("redemptionLimitDuration")]
+        public string? RedemptionLimitDuration { get; set; }
+    }
+
+    public class FixedTermPositionInterestCoinApy
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("apy")]
+        public string? Apy { get; set; }
+
+        [JsonProperty("expectReturnEarning")]
+        public string? ExpectReturnEarning { get; set; }
+
+        [JsonProperty("price")]
+        public string? Price { get; set; }
+    }
+
+    public class RedeemFixedTermResult
+    {
+        [JsonProperty("redeemAmount")]
+        public string? RedeemAmount { get; set; }
+
+        [JsonProperty("estEarnings")]
+        public string? EstEarnings { get; set; }
+    }
+
+    public class SetFixedTermAutoInvestResult
+    {
+    }
+}

--- a/Src/Common/Models/Earn/EarnSharedModels.cs
+++ b/Src/Common/Models/Earn/EarnSharedModels.cs
@@ -1,0 +1,110 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Earn
+{
+    public class PlaceEarnOrderResult
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+    }
+
+    public class GetEarnAprHistoryResult
+    {
+        [JsonProperty("list")]
+        public List<EarnAprHistoryItem>? List { get; set; }
+    }
+
+    public class EarnAprHistoryItem
+    {
+        [JsonProperty("timestamp")]
+        public string? Timestamp { get; set; }
+
+        [JsonProperty("apr")]
+        public string? Apr { get; set; }
+    }
+
+    public class GetEarnHourlyYieldResult
+    {
+        [JsonProperty("list")]
+        public List<EarnHourlyYieldItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class EarnHourlyYieldItem
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("effectiveStakingAmount")]
+        public string? EffectiveStakingAmount { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("hourlyDate")]
+        public string? HourlyDate { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+    }
+
+    public class GetEarnYieldHistoryResult
+    {
+        [JsonProperty("yield")]
+        public List<EarnYieldHistoryItem>? Yield { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class EarnYieldHistoryItem
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("yieldType")]
+        public string? YieldType { get; set; }
+
+        [JsonProperty("distributionMode")]
+        public string? DistributionMode { get; set; }
+
+        [JsonProperty("effectiveStakingAmount")]
+        public string? EffectiveStakingAmount { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+    }
+
+    public class ModifyEarnPositionResult
+    {
+    }
+}

--- a/Src/Common/Models/Earn/EarnTokenModels.cs
+++ b/Src/Common/Models/Earn/EarnTokenModels.cs
@@ -1,0 +1,193 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Earn
+{
+    public class GetTokenProductResult
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("mintFeeRateE8")]
+        public string? MintFeeRateE8 { get; set; }
+
+        [JsonProperty("redeemFeeRateE8")]
+        public string? RedeemFeeRateE8 { get; set; }
+
+        [JsonProperty("minInvestment")]
+        public string? MinInvestment { get; set; }
+
+        [JsonProperty("userHolding")]
+        public string? UserHolding { get; set; }
+
+        [JsonProperty("leftQuota")]
+        public string? LeftQuota { get; set; }
+
+        [JsonProperty("canMint")]
+        public bool? CanMint { get; set; }
+
+        [JsonProperty("savingsBalance")]
+        public string? SavingsBalance { get; set; }
+
+        [JsonProperty("aprE8")]
+        public string? AprE8 { get; set; }
+
+        [JsonProperty("bonusAprE8")]
+        public string? BonusAprE8 { get; set; }
+
+        [JsonProperty("bonusMaxAmount")]
+        public string? BonusMaxAmount { get; set; }
+
+        [JsonProperty("baseCoinPrecision")]
+        public int? BaseCoinPrecision { get; set; }
+
+        [JsonProperty("tokenPrecision")]
+        public int? TokenPrecision { get; set; }
+    }
+
+    public class PlaceTokenOrderResult
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+    }
+
+    public class GetTokenOrderListResult
+    {
+        [JsonProperty("list")]
+        public List<TokenOrderItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class TokenOrderItem
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+
+        [JsonProperty("orderType")]
+        public string? OrderType { get; set; }
+
+        [JsonProperty("fromCoin")]
+        public string? FromCoin { get; set; }
+
+        [JsonProperty("toCoin")]
+        public string? ToCoin { get; set; }
+
+        [JsonProperty("fromAmount")]
+        public string? FromAmount { get; set; }
+
+        [JsonProperty("toAmount")]
+        public string? ToAmount { get; set; }
+
+        [JsonProperty("serviceFee")]
+        public string? ServiceFee { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+    }
+
+    public class GetTokenPositionResult
+    {
+        [JsonProperty("totalAmount")]
+        public string? TotalAmount { get; set; }
+
+        [JsonProperty("totalYield")]
+        public string? TotalYield { get; set; }
+
+        [JsonProperty("yesterdayYield")]
+        public string? YesterdayYield { get; set; }
+
+        [JsonProperty("aprE8")]
+        public string? AprE8 { get; set; }
+
+        [JsonProperty("bonusAprE8")]
+        public string? BonusAprE8 { get; set; }
+
+        [JsonProperty("bonusMaxAmount")]
+        public string? BonusMaxAmount { get; set; }
+
+        [JsonProperty("hasQuota")]
+        public bool? HasQuota { get; set; }
+    }
+
+    public class GetTokenYieldResult
+    {
+        [JsonProperty("list")]
+        public List<TokenYieldItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class TokenYieldItem
+    {
+        [JsonProperty("yield")]
+        public string? Yield { get; set; }
+
+        [JsonProperty("bonusYield")]
+        public string? BonusYield { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+    }
+
+    public class GetTokenHourlyYieldResult
+    {
+        [JsonProperty("list")]
+        public List<TokenHourlyYieldItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
+    }
+
+    public class TokenHourlyYieldItem
+    {
+        [JsonProperty("effectiveAmount")]
+        public string? EffectiveAmount { get; set; }
+
+        [JsonProperty("yield")]
+        public string? Yield { get; set; }
+
+        [JsonProperty("rewardType")]
+        public int? RewardType { get; set; }
+
+        [JsonProperty("aprE8")]
+        public string? AprE8 { get; set; }
+
+        [JsonProperty("hourlyDate")]
+        public string? HourlyDate { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+    }
+
+    public class GetTokenHistoryAprResult
+    {
+        [JsonProperty("list")]
+        public List<TokenHistoryAprItem>? List { get; set; }
+    }
+
+    public class TokenHistoryAprItem
+    {
+        [JsonProperty("timestamp")]
+        public string? Timestamp { get; set; }
+
+        [JsonProperty("aprE8")]
+        public string? AprE8 { get; set; }
+    }
+}

--- a/Src/Common/Models/Earn/GetProductInfoResult.cs
+++ b/Src/Common/Models/Earn/GetProductInfoResult.cs
@@ -1,47 +1,91 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace bybit.net.api.Models.Earn
 {
     public class GetProductInfoResult
     {
-        public List<EarnProduct>? list { get; set; }
+        [JsonProperty("list")]
+        public List<EarnProduct>? List { get; set; }
     }
 
     public class EarnProduct
     {
-        public string? category { get; set; }                 // FlexibleSaving, OnChain
-        public string? estimateApr { get; set; }              // e.g., "3%", "4.25%"
-        public string? coin { get; set; }
-        public string? minStakeAmount { get; set; }
-        public string? maxStakeAmount { get; set; }
-        public string? precision { get; set; }
-        public string? productId { get; set; }
-        public string? status { get; set; }                   // Available, NotAvailable
-        public List<BonusEvent>? bonusEvents { get; set; }
-        public string? minRedeemAmount { get; set; }
-        public string? maxRedeemAmount { get; set; }
-        public string? duration { get; set; }                 // Fixed, Flexible
-        public int? term { get; set; }                        // days, for OnChain Fixed
-        public string? swapCoin { get; set; }
-        public string? swapCoinPrecision { get; set; }
-        public string? stakeExchangeRate { get; set; }
-        public string? redeemExchangeRate { get; set; }
-        public string? rewardDistributionType { get; set; }   // Simple, Compound, Other(LST)
-        public int? rewardIntervalMinute { get; set; }
-        public string? redeemProcessingMinute { get; set; }
-        public string? stakeTime { get; set; }                // ms
-        public string? interestCalculationTime { get; set; }  // ms
+        [JsonProperty("category")]
+        public string? Category { get; set; }
+
+        [JsonProperty("estimateApr")]
+        public string? EstimateApr { get; set; }
+
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("minStakeAmount")]
+        public string? MinStakeAmount { get; set; }
+
+        [JsonProperty("maxStakeAmount")]
+        public string? MaxStakeAmount { get; set; }
+
+        [JsonProperty("precision")]
+        public string? Precision { get; set; }
+
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("bonusEvents")]
+        public List<BonusEvent>? BonusEvents { get; set; }
+
+        [JsonProperty("minRedeemAmount")]
+        public string? MinRedeemAmount { get; set; }
+
+        [JsonProperty("maxRedeemAmount")]
+        public string? MaxRedeemAmount { get; set; }
+
+        [JsonProperty("duration")]
+        public string? Duration { get; set; }
+
+        [JsonProperty("term")]
+        public int? Term { get; set; }
+
+        [JsonProperty("swapCoin")]
+        public string? SwapCoin { get; set; }
+
+        [JsonProperty("swapCoinPrecision")]
+        public string? SwapCoinPrecision { get; set; }
+
+        [JsonProperty("stakeExchangeRate")]
+        public string? StakeExchangeRate { get; set; }
+
+        [JsonProperty("redeemExchangeRate")]
+        public string? RedeemExchangeRate { get; set; }
+
+        [JsonProperty("rewardDistributionType")]
+        public string? RewardDistributionType { get; set; }
+
+        [JsonProperty("rewardIntervalMinute")]
+        public int? RewardIntervalMinute { get; set; }
+
+        [JsonProperty("redeemProcessingMinute")]
+        public string? RedeemProcessingMinute { get; set; }
+
+        [JsonProperty("stakeTime")]
+        public string? StakeTime { get; set; }
+
+        [JsonProperty("interestCalculationTime")]
+        public string? InterestCalculationTime { get; set; }
     }
 
     public class BonusEvent
     {
-        public string? apr { get; set; }          // Yesterday's Rewards APR
-        public string? coin { get; set; }         // Reward coin
-        public string? announcement { get; set; } // link
-    }
+        [JsonProperty("apr")]
+        public string? Apr { get; set; }
 
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("announcement")]
+        public string? Announcement { get; set; }
+    }
 }

--- a/Src/Common/Models/Earn/GetStakeRedeemOrderHistoryResult.cs
+++ b/Src/Common/Models/Earn/GetStakeRedeemOrderHistoryResult.cs
@@ -1,30 +1,52 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace bybit.net.api.Models.Earn
 {
     public class GetStakeRedeemOrderHistoryResult
     {
-        public List<EarnOrderHistoryItem>? list { get; set; }
+        [JsonProperty("list")]
+        public List<EarnOrderHistoryItem>? List { get; set; }
+
+        [JsonProperty("nextPageCursor")]
+        public string? NextPageCursor { get; set; }
     }
 
     public class EarnOrderHistoryItem
     {
-        public string? coin { get; set; }
-        public string? orderValue { get; set; }
-        public string? orderType { get; set; }       // Redeem, Stake
-        public string? orderId { get; set; }
-        public string? orderLinkId { get; set; }
-        public string? status { get; set; }          // Success, Fail, Pending
-        public string? createdAt { get; set; }       // ms
-        public string? productId { get; set; }
-        public string? updatedAt { get; set; }       // ms
-        public string? swapOrderValue { get; set; }  // LST Onchain only
-        public string? estimateRedeemTime { get; set; } // Onchain only, ms
-        public string? estimateStakeTime { get; set; }  // Onchain only, ms
-    }
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
 
+        [JsonProperty("orderValue")]
+        public string? OrderValue { get; set; }
+
+        [JsonProperty("orderType")]
+        public string? OrderType { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderLinkId")]
+        public string? OrderLinkId { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("createdAt")]
+        public string? CreatedAt { get; set; }
+
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("updatedAt")]
+        public string? UpdatedAt { get; set; }
+
+        [JsonProperty("swapOrderValue")]
+        public string? SwapOrderValue { get; set; }
+
+        [JsonProperty("estimateRedeemTime")]
+        public string? EstimateRedeemTime { get; set; }
+
+        [JsonProperty("estimateStakeTime")]
+        public string? EstimateStakeTime { get; set; }
+    }
 }

--- a/Src/Common/Models/Earn/GetStakedPositionResult.cs
+++ b/Src/Common/Models/Earn/GetStakedPositionResult.cs
@@ -1,30 +1,52 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace bybit.net.api.Models.Earn
 {
     public class GetStakedPositionResult
     {
-        public List<EarnStakedPosition>? list { get; set; }
+        [JsonProperty("list")]
+        public List<EarnStakedPosition>? List { get; set; }
     }
 
     public class EarnStakedPosition
     {
-        public string? coin { get; set; }
-        public string? productId { get; set; }
-        public string? amount { get; set; }
-        public string? totalPnl { get; set; }                      // Onchain non-LST only
-        public string? claimableYield { get; set; }                // Not returned for Onchain
-        public string? id { get; set; }                            // Onchain only
-        public string? status { get; set; }                        // Processing, Active (Onchain)
-        public string? orderId { get; set; }                       // Onchain only
-        public string? estimateRedeemTime { get; set; }            // ms, Onchain only
-        public string? estimateStakeTime { get; set; }             // ms, Onchain only
-        public string? estimateInterestCalculationTime { get; set; } // ms, Onchain only
-        public string? settlementTime { get; set; }                // ms, Onchain Fixed only
-    }
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
 
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("amount")]
+        public string? Amount { get; set; }
+
+        [JsonProperty("totalPnl")]
+        public string? TotalPnl { get; set; }
+
+        [JsonProperty("claimableYield")]
+        public string? ClaimableYield { get; set; }
+
+        [JsonProperty("id")]
+        public string? Id { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("estimateRedeemTime")]
+        public string? EstimateRedeemTime { get; set; }
+
+        [JsonProperty("estimateStakeTime")]
+        public string? EstimateStakeTime { get; set; }
+
+        [JsonProperty("estimateInterestCalculationTime")]
+        public string? EstimateInterestCalculationTime { get; set; }
+
+        [JsonProperty("settlementTime")]
+        public string? SettlementTime { get; set; }
+
+        [JsonProperty("autoReinvest")]
+        public string? AutoReinvest { get; set; }
+    }
 }

--- a/Src/Common/Models/Lending/BizType.cs
+++ b/Src/Common/Models/Lending/BizType.cs
@@ -10,6 +10,7 @@
         public static BizType SPOT { get => new("SPOT"); }
         public static BizType DERIVATIVES { get => new("DERIVATIVES"); }
         public static BizType OPTIONS { get => new("OPTIONS"); }
+        public static BizType CONVERT { get => new("CONVERT"); }
         public string Value { get; private set; }
         public static implicit operator string(BizType bizType) => bizType.Value;
         public override readonly string ToString() => Value.ToString();

--- a/Src/Common/Models/Lending/C2CLendingModels.cs
+++ b/Src/Common/Models/Lending/C2CLendingModels.cs
@@ -1,0 +1,145 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Lending
+{
+    public class GetC2CLendingCoinInfoResult
+    {
+        [JsonProperty("list")]
+        public List<C2CLendingCoinInfo>? List { get; set; }
+    }
+
+    public class C2CLendingCoinInfo
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("maxRedeemQty")]
+        public string? MaxRedeemQty { get; set; }
+
+        [JsonProperty("minPurchaseQty")]
+        public string? MinPurchaseQty { get; set; }
+
+        [JsonProperty("precision")]
+        public string? Precision { get; set; }
+
+        [JsonProperty("rate")]
+        public string? Rate { get; set; }
+
+        [JsonProperty("loanToPoolRatio")]
+        public string? LoanToPoolRatio { get; set; }
+
+        [JsonProperty("actualApy")]
+        public string? ActualApy { get; set; }
+    }
+
+    public class C2CLendingOrderResult
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("quantity")]
+        public string? Quantity { get; set; }
+
+        [JsonProperty("serialNo")]
+        public string? SerialNo { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("updatedTime")]
+        public string? UpdatedTime { get; set; }
+    }
+
+    public class C2CRedeemOrderResult
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("principalQty")]
+        public string? PrincipalQty { get; set; }
+
+        [JsonProperty("serialNo")]
+        public string? SerialNo { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("updatedTime")]
+        public string? UpdatedTime { get; set; }
+    }
+
+    public class C2CCancelRedeemResult
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("serialNo")]
+        public string? SerialNo { get; set; }
+
+        [JsonProperty("updatedTime")]
+        public string? UpdatedTime { get; set; }
+    }
+
+    public class GetC2CLendingOrdersResult
+    {
+        [JsonProperty("list")]
+        public List<C2CLendingHistoryOrder>? List { get; set; }
+    }
+
+    public class C2CLendingHistoryOrder
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("createdTime")]
+        public string? CreatedTime { get; set; }
+
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderType")]
+        public string? OrderType { get; set; }
+
+        [JsonProperty("quantity")]
+        public string? Quantity { get; set; }
+
+        [JsonProperty("serialNo")]
+        public string? SerialNo { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("updatedTime")]
+        public string? UpdatedTime { get; set; }
+    }
+
+    public class GetC2CLendingAccountInfoResult
+    {
+        [JsonProperty("coin")]
+        public string? Coin { get; set; }
+
+        [JsonProperty("principalInterest")]
+        public string? PrincipalInterest { get; set; }
+
+        [JsonProperty("principalQty")]
+        public string? PrincipalQty { get; set; }
+
+        [JsonProperty("principalTotal")]
+        public string? PrincipalTotal { get; set; }
+
+        [JsonProperty("quantity")]
+        public string? Quantity { get; set; }
+    }
+}

--- a/Src/Common/Models/Lending/InstitutionalLendingModels.cs
+++ b/Src/Common/Models/Lending/InstitutionalLendingModels.cs
@@ -1,0 +1,310 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.Lending
+{
+    public class GetInsLoanInfoResult
+    {
+        [JsonProperty("marginProductInfo")]
+        public List<InsLoanProductInfo>? MarginProductInfo { get; set; }
+    }
+
+    public class InsLoanProductInfo
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("leverage")]
+        public string? Leverage { get; set; }
+
+        [JsonProperty("supportSpot")]
+        public int? SupportSpot { get; set; }
+
+        [JsonProperty("supportContract")]
+        public int? SupportContract { get; set; }
+
+        [JsonProperty("supportMarginTrading")]
+        public int? SupportMarginTrading { get; set; }
+
+        [JsonProperty("deferredLiquidationLine")]
+        public string? DeferredLiquidationLine { get; set; }
+
+        [JsonProperty("deferredLiquidationTime")]
+        public string? DeferredLiquidationTime { get; set; }
+
+        [JsonProperty("withdrawLine")]
+        public string? WithdrawLine { get; set; }
+
+        [JsonProperty("transferLine")]
+        public string? TransferLine { get; set; }
+
+        [JsonProperty("spotBuyLine")]
+        public string? SpotBuyLine { get; set; }
+
+        [JsonProperty("spotSellLine")]
+        public string? SpotSellLine { get; set; }
+
+        [JsonProperty("contractOpenLine")]
+        public string? ContractOpenLine { get; set; }
+
+        [JsonProperty("liquidationLine")]
+        public string? LiquidationLine { get; set; }
+
+        [JsonProperty("stopLiquidationLine")]
+        public string? StopLiquidationLine { get; set; }
+
+        [JsonProperty("contractLeverage")]
+        public string? ContractLeverage { get; set; }
+
+        [JsonProperty("transferRatio")]
+        public string? TransferRatio { get; set; }
+
+        [JsonProperty("spotSymbols")]
+        public List<string>? SpotSymbols { get; set; }
+
+        [JsonProperty("contractSymbols")]
+        public List<string>? ContractSymbols { get; set; }
+
+        [JsonProperty("supportUSDCContract")]
+        public int? SupportUsdcContract { get; set; }
+
+        [JsonProperty("supportUSDCOptions")]
+        public int? SupportUsdcOptions { get; set; }
+
+        [JsonProperty("USDTPerpetualOpenLine")]
+        public string? UsdtPerpetualOpenLine { get; set; }
+
+        [JsonProperty("USDCContractOpenLine")]
+        public string? UsdcContractOpenLine { get; set; }
+
+        [JsonProperty("USDCOptionsOpenLine")]
+        public string? UsdcOptionsOpenLine { get; set; }
+
+        [JsonProperty("USDTPerpetualCloseLine")]
+        public string? UsdtPerpetualCloseLine { get; set; }
+
+        [JsonProperty("USDCContractCloseLine")]
+        public string? UsdcContractCloseLine { get; set; }
+
+        [JsonProperty("USDCOptionsCloseLine")]
+        public string? UsdcOptionsCloseLine { get; set; }
+
+        [JsonProperty("USDCContractSymbols")]
+        public List<string>? UsdcContractSymbols { get; set; }
+
+        [JsonProperty("USDCOptionsSymbols")]
+        public List<string>? UsdcOptionsSymbols { get; set; }
+
+        [JsonProperty("marginLeverage")]
+        public string? MarginLeverage { get; set; }
+
+        [JsonProperty("USDTPerpetualLeverage")]
+        public List<InsLoanSymbolLeverage>? UsdtPerpetualLeverage { get; set; }
+
+        [JsonProperty("USDCContractLeverage")]
+        public List<InsLoanSymbolLeverage>? UsdcContractLeverage { get; set; }
+    }
+
+    public class InsLoanSymbolLeverage
+    {
+        [JsonProperty("symbol")]
+        public string? Symbol { get; set; }
+
+        [JsonProperty("leverage")]
+        public string? Leverage { get; set; }
+    }
+
+    public class GetInsMarginCoinInfoResult
+    {
+        [JsonProperty("marginToken")]
+        public List<InsMarginTokenInfo>? MarginToken { get; set; }
+    }
+
+    public class InsMarginTokenInfo
+    {
+        [JsonProperty("productId")]
+        public string? ProductId { get; set; }
+
+        [JsonProperty("tokenInfo")]
+        public List<InsMarginTokenDetail>? TokenInfo { get; set; }
+    }
+
+    public class InsMarginTokenDetail
+    {
+        [JsonProperty("token")]
+        public string? Token { get; set; }
+
+        [JsonProperty("convertRatioList")]
+        public List<InsMarginConvertRatio>? ConvertRatioList { get; set; }
+    }
+
+    public class InsMarginConvertRatio
+    {
+        [JsonProperty("ladder")]
+        public string? Ladder { get; set; }
+
+        [JsonProperty("convertRatio")]
+        public string? ConvertRatio { get; set; }
+    }
+
+    public class GetInsLoanOrdersResult
+    {
+        [JsonProperty("loanInfo")]
+        public List<InsLoanOrderInfo>? LoanInfo { get; set; }
+    }
+
+    public class InsLoanOrderInfo : InsLoanProductInfo
+    {
+        [JsonProperty("orderId")]
+        public string? OrderId { get; set; }
+
+        [JsonProperty("orderProductId")]
+        public string? OrderProductId { get; set; }
+
+        [JsonProperty("parentUid")]
+        public string? ParentUid { get; set; }
+
+        [JsonProperty("loanTime")]
+        public string? LoanTime { get; set; }
+
+        [JsonProperty("loanCoin")]
+        public string? LoanCoin { get; set; }
+
+        [JsonProperty("loanAmount")]
+        public string? LoanAmount { get; set; }
+
+        [JsonProperty("unpaidAmount")]
+        public string? UnpaidAmount { get; set; }
+
+        [JsonProperty("unpaidInterest")]
+        public string? UnpaidInterest { get; set; }
+
+        [JsonProperty("repaidAmount")]
+        public string? RepaidAmount { get; set; }
+
+        [JsonProperty("repaidInterest")]
+        public string? RepaidInterest { get; set; }
+
+        [JsonProperty("interestRate")]
+        public string? InterestRate { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+
+        [JsonProperty("reserveToken")]
+        public string? ReserveToken { get; set; }
+
+        [JsonProperty("reserveQuantity")]
+        public string? ReserveQuantity { get; set; }
+    }
+
+    public class GetInsLoanRepayOrdersResult
+    {
+        [JsonProperty("repayInfo")]
+        public List<InsLoanRepayOrderInfo>? RepayInfo { get; set; }
+    }
+
+    public class InsLoanRepayOrderInfo
+    {
+        [JsonProperty("repayOrderId")]
+        public string? RepayOrderId { get; set; }
+
+        [JsonProperty("repaidTime")]
+        public string? RepaidTime { get; set; }
+
+        [JsonProperty("token")]
+        public string? Token { get; set; }
+
+        [JsonProperty("quantity")]
+        public string? Quantity { get; set; }
+
+        [JsonProperty("interest")]
+        public string? Interest { get; set; }
+
+        [JsonProperty("businessType")]
+        public string? BusinessType { get; set; }
+
+        [JsonProperty("status")]
+        public string? Status { get; set; }
+    }
+
+    public class GetInsLoanToValueResult
+    {
+        [JsonProperty("ltvInfo")]
+        public List<InsLoanToValueInfo>? LtvInfo { get; set; }
+
+        [JsonProperty("liqStatus")]
+        public int? LiqStatus { get; set; }
+    }
+
+    public class InsLoanToValueInfo
+    {
+        [JsonProperty("ltv")]
+        public string? Ltv { get; set; }
+
+        [JsonProperty("rst")]
+        public string? Rst { get; set; }
+
+        [JsonProperty("parentUid")]
+        public string? ParentUid { get; set; }
+
+        [JsonProperty("subAccountUids")]
+        public List<string>? SubAccountUids { get; set; }
+
+        [JsonProperty("unpaidAmount")]
+        public string? UnpaidAmount { get; set; }
+
+        [JsonProperty("unpaidInfo")]
+        public List<InsLoanUnpaidInfo>? UnpaidInfo { get; set; }
+
+        [JsonProperty("balance")]
+        public string? Balance { get; set; }
+
+        [JsonProperty("balanceInfo")]
+        public List<InsLoanBalanceInfo>? BalanceInfo { get; set; }
+
+        [JsonProperty("liqStatus")]
+        public int? LiqStatus { get; set; }
+    }
+
+    public class InsLoanUnpaidInfo
+    {
+        [JsonProperty("token")]
+        public string? Token { get; set; }
+
+        [JsonProperty("unpaidQty")]
+        public string? UnpaidQty { get; set; }
+
+        [JsonProperty("unpaidInterest")]
+        public string? UnpaidInterest { get; set; }
+    }
+
+    public class InsLoanBalanceInfo
+    {
+        [JsonProperty("token")]
+        public string? Token { get; set; }
+
+        [JsonProperty("price")]
+        public string? Price { get; set; }
+
+        [JsonProperty("qty")]
+        public string? Qty { get; set; }
+
+        [JsonProperty("convertedAmount")]
+        public string? ConvertedAmount { get; set; }
+    }
+
+    public class UpdateInsLoanUidResult
+    {
+        [JsonProperty("uid")]
+        public string? Uid { get; set; }
+
+        [JsonProperty("operate")]
+        public string? Operate { get; set; }
+    }
+
+    public class RepayInsLoanResult
+    {
+        [JsonProperty("repayOrderStatus")]
+        public string? RepayOrderStatus { get; set; }
+    }
+}

--- a/Src/Common/Models/Market/MarketAdditionalResults.cs
+++ b/Src/Common/Models/Market/MarketAdditionalResults.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+
+namespace bybit.net.api.Models.Market
+{
+    public class GetRecentTradeResult
+    {
+        public string? category { get; set; }
+        public List<RecentTradeEntry>? list { get; set; }
+    }
+
+    public class RecentTradeEntry
+    {
+        public string? execId { get; set; }
+        public string? symbol { get; set; }
+        public string? price { get; set; }
+        public string? size { get; set; }
+        public string? side { get; set; }
+        public string? time { get; set; }
+        public bool? isBlockTrade { get; set; }
+        public bool? isRPITrade { get; set; }
+        public string? mP { get; set; }
+        public string? iP { get; set; }
+        public string? mIv { get; set; }
+        public string? iv { get; set; }
+        public string? seq { get; set; }
+    }
+
+    public class GetOpenInterestResult
+    {
+        public string? symbol { get; set; }
+        public string? category { get; set; }
+        public List<OpenInterestEntry>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class OpenInterestEntry
+    {
+        public string? openInterest { get; set; }
+        public string? timestamp { get; set; }
+    }
+
+    public class GetInsurancePoolResult
+    {
+        public string? updatedTime { get; set; }
+        public List<InsurancePoolEntry>? list { get; set; }
+    }
+
+    public class InsurancePoolEntry
+    {
+        public string? coin { get; set; }
+        public string? symbols { get; set; }
+        public string? balance { get; set; }
+        public string? value { get; set; }
+    }
+
+    public class GetDeliveryPriceResult
+    {
+        public string? category { get; set; }
+        public List<DeliveryPriceEntry>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class DeliveryPriceEntry
+    {
+        public string? symbol { get; set; }
+        public string? deliveryPrice { get; set; }
+        public string? deliveryTime { get; set; }
+    }
+
+    public class GetIndexPriceComponentsResult
+    {
+        public string? indexName { get; set; }
+        public string? lastPrice { get; set; }
+        public string? updateTime { get; set; }
+        public List<IndexPriceComponentEntry>? components { get; set; }
+    }
+
+    public class IndexPriceComponentEntry
+    {
+        public string? exchange { get; set; }
+        public string? spotPair { get; set; }
+        public string? equivalentPrice { get; set; }
+        public string? multiplier { get; set; }
+        public string? price { get; set; }
+        public string? weight { get; set; }
+    }
+
+    public class GetAdlAlertResult
+    {
+        public string? updatedTime { get; set; }
+        public List<AdlAlertEntry>? list { get; set; }
+    }
+
+    public class AdlAlertEntry
+    {
+        public string? coin { get; set; }
+        public string? symbol { get; set; }
+        public string? balance { get; set; }
+        public string? maxBalance { get; set; }
+        public string? insurancePnlRatio { get; set; }
+        public string? pnlRatio { get; set; }
+        public string? adlTriggerThreshold { get; set; }
+        public string? adlStopRatio { get; set; }
+    }
+
+    public class GetFeeGroupInfoResult
+    {
+        public List<FeeGroupInfoEntry>? list { get; set; }
+    }
+
+    public class FeeGroupInfoEntry
+    {
+        public string? groupName { get; set; }
+        public int? weightingFactor { get; set; }
+        public int? symbolsNumbers { get; set; }
+        public List<string>? symbols { get; set; }
+        public FeeRates? feeRates { get; set; }
+        public string? updateTime { get; set; }
+    }
+
+    public class FeeRates
+    {
+        public List<FeeRateDetail>? pro { get; set; }
+        public List<FeeRateDetail>? marketMaker { get; set; }
+    }
+
+    public class FeeRateDetail
+    {
+        public string? level { get; set; }
+        public string? takerFeeRate { get; set; }
+        public string? makerFeeRate { get; set; }
+        public string? makerRebate { get; set; }
+    }
+}

--- a/Src/Common/Models/P2P/GetChatMessageResult.cs
+++ b/Src/Common/Models/P2P/GetChatMessageResult.cs
@@ -8,7 +8,7 @@ namespace bybit.net.api.Models.P2P
 {
     public class GetChatMessageResult
     {
-        public List<P2pChatMessage>? list { get; set; }
+        public List<P2pChatMessage>? result { get; set; }
     }
 
     public class P2pChatMessage

--- a/Src/Common/Models/P2P/P2PResponse.cs
+++ b/Src/Common/Models/P2P/P2PResponse.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+
+namespace bybit.net.api.Models.P2P
+{
+    public class P2PResponse<T>
+    {
+        [JsonProperty("ret_code")]
+        public int? RetCode { get; set; }
+
+        [JsonProperty("ret_msg")]
+        public string? RetMsg { get; set; }
+
+        [JsonProperty("result")]
+        public T? Result { get; set; }
+
+        [JsonProperty("token")]
+        public string? Token { get; set; }
+
+        [JsonProperty("ext_code")]
+        public string? ExtCode { get; set; }
+
+        [JsonProperty("ext_info")]
+        public Dictionary<string, object>? ExtInfo { get; set; }
+
+        [JsonProperty("ext_map")]
+        public Dictionary<string, object>? ExtMap { get; set; }
+
+        [JsonProperty("time_now")]
+        public string? TimeNow { get; set; }
+    }
+}

--- a/Src/Common/Models/P2P/UploadChatFileResult.cs
+++ b/Src/Common/Models/P2P/UploadChatFileResult.cs
@@ -1,0 +1,8 @@
+namespace bybit.net.api.Models.P2P
+{
+    public class UploadChatFileResult
+    {
+        public string? url { get; set; }
+        public string? type { get; set; }
+    }
+}

--- a/Src/Common/Models/Position/Response/PositionResponseModels.cs
+++ b/Src/Common/Models/Position/Response/PositionResponseModels.cs
@@ -1,0 +1,136 @@
+namespace bybit.net.api.Models.Position.Response
+{
+    public class GetPositionInfoResult
+    {
+        public string? category { get; set; }
+        public string? nextPageCursor { get; set; }
+        public List<PositionInfo>? list { get; set; }
+    }
+
+    public class PositionInfo
+    {
+        public int? positionIdx { get; set; }
+        public int? riskId { get; set; }
+        public string? riskLimitValue { get; set; }
+        public string? symbol { get; set; }
+        public string? side { get; set; }
+        public string? size { get; set; }
+        public string? avgPrice { get; set; }
+        public string? positionValue { get; set; }
+        public int? autoAddMargin { get; set; }
+        public string? positionStatus { get; set; }
+        public string? leverage { get; set; }
+        public string? breakEvenPrice { get; set; }
+        public string? markPrice { get; set; }
+        public string? liqPrice { get; set; }
+        public string? positionIM { get; set; }
+        public string? positionIMByMp { get; set; }
+        public string? positionMM { get; set; }
+        public string? positionMMByMp { get; set; }
+        public string? takeProfit { get; set; }
+        public string? stopLoss { get; set; }
+        public string? trailingStop { get; set; }
+        public string? sessionAvgPrice { get; set; }
+        public string? delta { get; set; }
+        public string? gamma { get; set; }
+        public string? vega { get; set; }
+        public string? theta { get; set; }
+        public string? unrealisedPnl { get; set; }
+        public string? curRealisedPnl { get; set; }
+        public string? cumRealisedPnl { get; set; }
+        public int? adlRankIndicator { get; set; }
+        public string? createdTime { get; set; }
+        public string? updatedTime { get; set; }
+        public long? seq { get; set; }
+        public bool? isReduceOnly { get; set; }
+        public string? mmrSysUpdatedTime { get; set; }
+        public string? leverageSysUpdatedTime { get; set; }
+        public string? tpslMode { get; set; }
+        public string? bustPrice { get; set; }
+        public string? positionBalance { get; set; }
+        public int? tradeMode { get; set; }
+    }
+
+    public class PositionMarginResult
+    {
+        public string? category { get; set; }
+        public string? symbol { get; set; }
+        public int? positionIdx { get; set; }
+        public int? riskId { get; set; }
+        public string? riskLimitValue { get; set; }
+        public string? size { get; set; }
+        public string? avgPrice { get; set; }
+        public string? liqPrice { get; set; }
+        public string? bustPrice { get; set; }
+        public string? markPrice { get; set; }
+        public string? positionValue { get; set; }
+        public string? leverage { get; set; }
+        public int? autoAddMargin { get; set; }
+        public string? positionStatus { get; set; }
+        public string? positionIM { get; set; }
+        public string? positionMM { get; set; }
+        public string? takeProfit { get; set; }
+        public string? stopLoss { get; set; }
+        public string? trailingStop { get; set; }
+        public string? unrealisedPnl { get; set; }
+        public string? cumRealisedPnl { get; set; }
+        public string? createdTime { get; set; }
+        public string? updatedTime { get; set; }
+    }
+
+    public class GetClosedPnlResult
+    {
+        public string? category { get; set; }
+        public List<ClosedPnl>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class ClosedPnl
+    {
+        public string? symbol { get; set; }
+        public string? orderId { get; set; }
+        public string? side { get; set; }
+        public string? qty { get; set; }
+        public string? orderPrice { get; set; }
+        public string? orderType { get; set; }
+        public string? execType { get; set; }
+        public string? closedSize { get; set; }
+        public string? cumEntryValue { get; set; }
+        public string? avgEntryPrice { get; set; }
+        public string? cumExitValue { get; set; }
+        public string? avgExitPrice { get; set; }
+        public string? closedPnl { get; set; }
+        public string? fillCount { get; set; }
+        public string? leverage { get; set; }
+        public string? openFee { get; set; }
+        public string? closeFee { get; set; }
+        public string? createdTime { get; set; }
+        public string? updatedTime { get; set; }
+    }
+
+    public class GetMovePositionHistoryResult
+    {
+        public List<MovePositionHistory>? list { get; set; }
+        public string? nextPageCursor { get; set; }
+    }
+
+    public class MovePositionHistory
+    {
+        public string? blockTradeId { get; set; }
+        public string? category { get; set; }
+        public string? orderId { get; set; }
+        public long? userId { get; set; }
+        public string? symbol { get; set; }
+        public string? side { get; set; }
+        public string? price { get; set; }
+        public string? qty { get; set; }
+        public string? execFee { get; set; }
+        public string? status { get; set; }
+        public string? execId { get; set; }
+        public int? resultCode { get; set; }
+        public string? resultMessage { get; set; }
+        public long? createdAt { get; set; }
+        public long? updatedAt { get; set; }
+        public string? rejectParty { get; set; }
+    }
+}

--- a/Src/Common/Models/RFQ/RfqLeg.cs
+++ b/Src/Common/Models/RFQ/RfqLeg.cs
@@ -12,5 +12,6 @@ namespace bybit.net.api.Models.RFQ
         public string? symbol { get; set; }    // contract name
         public string? side { get; set; }      // Buy | Sell
         public string? qty { get; set; }       // quantity
+        public string? price { get; set; }     // quote price
     }
 }

--- a/Src/Common/Models/RateLimit/GetAllApiRateLimitsResponse.cs
+++ b/Src/Common/Models/RateLimit/GetAllApiRateLimitsResponse.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 
 namespace bybit.net.api.Models.RateLimit
 {
+    public class GetApiRateLimitResponse
+    {
+        public List<GetApiRateLimitItem>? list { get; set; }
+    }
+
     public class GetAllApiRateLimitsResponse
     {
         public string? nextPageCursor { get; set; }

--- a/Src/Common/Models/SpotMargin/SpotMarginMode.cs
+++ b/Src/Common/Models/SpotMargin/SpotMarginMode.cs
@@ -7,8 +7,8 @@
             Value = value;
         }
 
-        public static SpotMarginMode ON => new(0);
-        public static SpotMarginMode OFF => new(1);
+        public static SpotMarginMode ON => new(1);
+        public static SpotMarginMode OFF => new(0);
 
         public int Value { get; private set; }
 

--- a/Src/Common/Security/BybitHmacSignatureGenerator.cs
+++ b/Src/Common/Security/BybitHmacSignatureGenerator.cs
@@ -28,6 +28,12 @@ namespace bybit.net.api
         public string GeneratePostSignature(IDictionary<string, object> parameters)
         {
             string paramJson = JsonConvert.SerializeObject(parameters);
+            return GeneratePostSignature(paramJson);
+        }
+
+        public string GeneratePostSignature(string body)
+        {
+            string paramJson = body;
             string rawData = $"{currentTimeStamp}{apikey}{recWindow}{paramJson}";
             return Sign(rawData);
         }

--- a/Src/Common/Security/BybitHmacSignatureGenerator.cs
+++ b/Src/Common/Security/BybitHmacSignatureGenerator.cs
@@ -46,6 +46,11 @@ namespace bybit.net.api
         public string GenerateGetSignature(IDictionary<string, object> parameters)
         {
             string queryString = GenerateQueryString(parameters);
+            return GenerateGetSignature(queryString);
+        }
+
+        public string GenerateGetSignature(string queryString)
+        {
             string rawData = $"{currentTimeStamp}{apikey}{recWindow}{queryString}";
             return Sign(rawData);
         }

--- a/Src/Common/Security/IBybitSignatureService.cs
+++ b/Src/Common/Security/IBybitSignatureService.cs
@@ -3,6 +3,8 @@
     public interface IBybitSignatureService
     {
         string GeneratePostSignature(IDictionary<string, object> parameters);
+        string GeneratePostSignature(string body);
         string GenerateGetSignature(IDictionary<string, object> parameters);
+        string GenerateGetSignature(string queryString);
     }
 }

--- a/Src/Common/Services/BybitService.cs
+++ b/Src/Common/Services/BybitService.cs
@@ -85,13 +85,14 @@ namespace bybit.net.api
             IBybitSignatureService bybitSignatureService = new BybitHmacSignatureGenerator(apiKey, apiSecret, timestamp, recvWindow);
             if (httpMethod == HttpMethod.Get)
             {
-                requestUri = queryStringBuilder.Length > 0 ? requestUri + "?" + queryStringBuilder.ToString() : requestUri;
-                signature = bybitSignatureService.GenerateGetSignature(query ?? new Dictionary<string, object>());
+                var queryString = queryStringBuilder.ToString();
+                requestUri = queryString.Length > 0 ? requestUri + "?" + queryString : requestUri;
+                signature = bybitSignatureService.GenerateGetSignature(queryString);
             }
             else if (httpMethod == HttpMethod.Post)
             {
-                content = JsonConvert.SerializeObject(query);
-                signature = bybitSignatureService.GeneratePostSignature(query ?? new Dictionary<string, object>());
+                content = JsonConvert.SerializeObject(query ?? new Dictionary<string, object>());
+                signature = bybitSignatureService.GeneratePostSignature(content);
             }
 
             return await SendAsync<T>(requestUri, httpMethod, signature, content ?? null, timestamp);

--- a/Src/Common/Services/BybitService.cs
+++ b/Src/Common/Services/BybitService.cs
@@ -81,7 +81,8 @@ namespace bybit.net.api
             }
 
             string? signature = null, content = null;
-            IBybitSignatureService bybitSignatureService = new BybitHmacSignatureGenerator(apiKey, apiSecret, CurrentTimeStamp, recvWindow);
+            var timestamp = CurrentTimeStamp;
+            IBybitSignatureService bybitSignatureService = new BybitHmacSignatureGenerator(apiKey, apiSecret, timestamp, recvWindow);
             if (httpMethod == HttpMethod.Get)
             {
                 requestUri = queryStringBuilder.Length > 0 ? requestUri + "?" + queryStringBuilder.ToString() : requestUri;
@@ -93,7 +94,26 @@ namespace bybit.net.api
                 signature = bybitSignatureService.GeneratePostSignature(query ?? new Dictionary<string, object>());
             }
 
-            return await SendAsync<T>(requestUri, httpMethod, signature, content ?? null);
+            return await SendAsync<T>(requestUri, httpMethod, signature, content ?? null, timestamp);
+        }
+
+        /// <summary>
+        /// Sends an asynchronous signed multipart request to Bybit API.
+        /// </summary>
+        /// <typeparam name="T">The type of object to deserialize the response into.</typeparam>
+        /// <param name="requestUri">The URI of the endpoint to request.</param>
+        /// <param name="content">Multipart form-data content.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized response object of type T.</returns>
+        protected async Task<T?> SendSignedMultipartAsync<T>(string requestUri, MultipartFormDataContent content)
+        {
+            var timestamp = CurrentTimeStamp;
+            var bybitSignatureService = new BybitHmacSignatureGenerator(apiKey, apiSecret, timestamp, recvWindow);
+            string signature = bybitSignatureService.GeneratePostSignature(string.Empty);
+
+            using HttpRequestMessage request = BuildHttpRequest(requestUri, HttpMethod.Post, signature, timestamp);
+            request.Content = content;
+
+            return await SendAsync<T>(request, requestUri);
         }
         #endregion
 
@@ -143,10 +163,15 @@ namespace bybit.net.api
         /// <param name="signature">Optional signature for authentication.</param>
         /// <param name="content">Optional content to include in the request body.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the deserialized response object of type T or throws an exception if there's an issue.</returns>
-        private async Task<T?> SendAsync<T>(string requestUri, HttpMethod httpMethod, string? signature = null, string? content = null)
+        private async Task<T?> SendAsync<T>(string requestUri, HttpMethod httpMethod, string? signature = null, string? content = null, string? timestamp = null)
         {
-            using HttpRequestMessage request = BuildHttpRequest(requestUri, httpMethod, signature, content);
+            using HttpRequestMessage request = BuildHttpRequest(requestUri, httpMethod, signature, timestamp ?? CurrentTimeStamp, content);
 
+            return await SendAsync<T>(request, requestUri);
+        }
+
+        private async Task<T?> SendAsync<T>(HttpRequestMessage request, string requestUri)
+        {
             LogHttpRequestHeader(request);
 
             HttpResponseMessage response = await this.httpClient.SendAsync(request);
@@ -248,9 +273,10 @@ namespace bybit.net.api
         /// <param name="requestUri">The URI of the endpoint to request.</param>
         /// <param name="httpMethod">The HTTP method (GET, POST, etc.) of the request.</param>
         /// <param name="signature">Optional signature for authentication.</param>
+        /// <param name="timestamp">Request timestamp.</param>
         /// <param name="content">Optional content to include in the request body.</param>
         /// <returns>Http Request message</returns>
-        private HttpRequestMessage BuildHttpRequest(string requestUri, HttpMethod httpMethod, string? signature, string? content)
+        private HttpRequestMessage BuildHttpRequest(string requestUri, HttpMethod httpMethod, string? signature, string timestamp, string? content = null)
         {
             var baseUrl = this.url;
             var request = new HttpRequestMessage(httpMethod, baseUrl + requestUri);
@@ -260,7 +286,7 @@ namespace bybit.net.api
             }
             request.Headers.Add("User-Agent", UserAgent);
             request.Headers.Add("X-BAPI-SIGN-TYPE", BybitConstants.DEFAULT_SIGN_TYPE);
-            request.Headers.Add("X-BAPI-TIMESTAMP", CurrentTimeStamp);
+            request.Headers.Add("X-BAPI-TIMESTAMP", timestamp);
             request.Headers.Add("X-BAPI-RECV-WINDOW", recvWindow);
             if (this.apiKey is not null)
             {

--- a/Src/Common/Utils/VersionInfo.cs
+++ b/Src/Common/Utils/VersionInfo.cs
@@ -2,7 +2,7 @@
 {
     public static class VersionInfo
     {
-        private static readonly string version = "1.2.1";
+        private static readonly string version = "1.3.0";
 
         public static string GetVersion
         {

--- a/Src/Common/bybit.net.api.csproj
+++ b/Src/Common/bybit.net.api.csproj
@@ -25,8 +25,8 @@ Dive into a plethora of functionalities:
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/wuhewuhe/bybit.net.api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <VersionPrefix>1.2.1</VersionPrefix>
-    <AssemblyVersion>1.2.1</AssemblyVersion>
+    <VersionPrefix>1.3.0</VersionPrefix>
+    <AssemblyVersion>1.3.0</AssemblyVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageTags>Bybit Future Spot Trading Option Inverse Linear Api Crypto Rest Http Https Webscoket WSS OpenApi</PackageTags>
     <PackageReleaseNotes>

--- a/Src/Common/bybit.net.api.csproj
+++ b/Src/Common/bybit.net.api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -63,8 +63,6 @@ Dive into a plethora of functionalities:
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Common/bybit.net.api.csproj.bak
+++ b/Src/Common/bybit.net.api.csproj.bak
@@ -14,8 +14,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/wuhewuhe/bybit.net.api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-	<VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
+	<VersionPrefix>1.3.0</VersionPrefix>
+    <AssemblyVersion>1.3.0</AssemblyVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageTags>Bybit Api Crypto Rest Http Webscoket</PackageTags>
     <PackageReleaseNotes>Bybit.Net.Api is under active development with the latest features and updates from Bybit's API implemented promptly. The module utilizes minimal external libraries to provide a lightweight and efficient experience.</PackageReleaseNotes>

--- a/Src/Common/bybit.net.api.csproj.bak
+++ b/Src/Common/bybit.net.api.csproj.bak
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/Tests/bybit.api.test/MarketDataServiceTest.cs
+++ b/Tests/bybit.api.test/MarketDataServiceTest.cs
@@ -1,7 +1,6 @@
 ﻿using bybit.net.api.ApiServiceImp;
 using bybit.net.api.Models.Market;
 using bybit.net.api.Models;
-using Newtonsoft.Json;
 using Xunit;
 using bybit.net.api;
 
@@ -14,11 +13,9 @@ namespace bybit.api.test
         [Fact]
         public async Task CheckMarketKline_ResponseAsync()
         {
-            var klineInfoString = await marketDataService.GetMarketKline(category: Category.SPOT, symbol: "BTCUSDT", interval: MarketInterval.OneHour, start: 1693785600000, limit: 2);
-            if (!string.IsNullOrEmpty(klineInfoString))
+            var generalResponse = await marketDataService.GetMarketKline(category: Category.SPOT, symbol: "BTCUSDT", interval: MarketInterval.OneHour, start: 1693785600000, limit: 2);
+            if (generalResponse != null)
             {
-                Console.WriteLine(klineInfoString);
-                var generalResponse = JsonConvert.DeserializeObject<GeneralResponse<MarketKLineResult>>(klineInfoString);
                 var klineInfo = generalResponse?.Result;
 
                 Assert.Equal(0, generalResponse?.RetCode);
@@ -32,11 +29,9 @@ namespace bybit.api.test
         [Fact]
         public async Task CheckMarketTcikers_ResponseAsync()
         {
-            var tickersInfoString = await marketDataService.GetMarketTickers(category: Category.SPOT);
-            if (!string.IsNullOrEmpty(tickersInfoString))
+            var generalResponse = await marketDataService.GetMarketTickers(category: Category.SPOT);
+            if (generalResponse != null)
             {
-                Console.WriteLine(tickersInfoString);
-                var generalResponse = JsonConvert.DeserializeObject<GeneralResponse<MarketTickerResult>>(tickersInfoString);
                 var tickersInfo = generalResponse?.Result;
 
                 Assert.Equal(0, generalResponse?.RetCode);
@@ -50,11 +45,9 @@ namespace bybit.api.test
         [Fact]
         public async Task CheckFundingRate_ResponseAsync()
         {
-            var fundingInfoString = await marketDataService.GetMarketFundingHistory(category: Category.LINEAR, symbol: "BTCUSDT");
-            if (!string.IsNullOrEmpty(fundingInfoString))
+            var generalResponse = await marketDataService.GetMarketFundingHistory(category: Category.LINEAR, symbol: "BTCUSDT");
+            if (generalResponse != null)
             {
-                Console.WriteLine(fundingInfoString);
-                var generalResponse = JsonConvert.DeserializeObject<GeneralResponse<FundingRateResult>>(fundingInfoString);
                 var fundingInfo = generalResponse?.Result;
 
                 Assert.Equal(0, generalResponse?.RetCode);

--- a/Tests/bybit.api.test/Tests/AccountServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/AccountServiceEndpointTests.cs
@@ -1,0 +1,156 @@
+using bybit.net.api.ApiServiceImp;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Account;
+using bybit.net.api.Models.Account.Response;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class AccountServiceEndpointTests
+    {
+        [Fact]
+        public async Task SetAccountMarginMode_UsesLowerCaseRequestField()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"reasons\":[]},\"time\":1}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/account/set-margin-mode" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"setMarginMode\":\"PORTFOLIO_MARGIN\"")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var httpClient = new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bybit.com")
+            };
+
+            var accountService = new BybitAccountService(httpClient, "key", "secret");
+            var result = await accountService.SetAccountMarginMode(SetMarginMode.PORTFOLIO_MARGIN);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result!.RetCode);
+            Assert.Empty(result.Result!.Reasons!);
+        }
+
+        [Fact]
+        public async Task ManualRepay_MapsRepaymentType()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"resultStatus\":\"P\"},\"time\":1}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/account/repay" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"repaymentType\":\"ALL\"")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var httpClient = new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bybit.com")
+            };
+
+            var accountService = new BybitAccountService(httpClient, "key", "secret");
+            var result = await accountService.ManualRepay("BTC", "0.01", RepaymentType.All);
+
+            Assert.NotNull(result);
+            Assert.Equal("P", result!.Result!.ResultStatus);
+        }
+
+        [Fact]
+        public async Task ManualRepayWithoutAssetConversion_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"resultStatus\":\"SU\"},\"time\":1}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/v5/account/no-convert-repay", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var httpClient = new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bybit.com")
+            };
+
+            var accountService = new BybitAccountService(httpClient, "key", "secret");
+            var result = await accountService.ManualRepayWithoutAssetConversion("BTC");
+
+            Assert.NotNull(result);
+            Assert.Equal("SU", result!.Result!.ResultStatus);
+        }
+
+        [Fact]
+        public async Task GetAccountInstrumentsInfo_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"category\":\"spot\",\"list\":[{\"symbol\":\"BTCUSDT\"}]},\"time\":1}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/v5/account/instruments-info", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var httpClient = new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bybit.com")
+            };
+
+            var accountService = new BybitAccountService(httpClient, "key", "secret");
+            var result = await accountService.GetAccountInstrumentsInfo(Category.SPOT, "BTCUSDT");
+
+            Assert.NotNull(result);
+            Assert.Equal("spot", result!.Result!.Category);
+            Assert.Equal("BTCUSDT", result.Result.List![0].Symbol);
+        }
+
+        [Fact]
+        public async Task GetTransferableAmount_MapsResponse()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"availableWithdrawal\":\"4.5\",\"availableWithdrawalMap\":{\"BTC\":\"4.5\"}},\"time\":1}";
+            var mockMessageHandler = new Mock<HttpMessageHandler>();
+            mockMessageHandler.Protected()
+                .SetupSendAsync("/v5/account/withdrawal", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var httpClient = new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://api.bybit.com")
+            };
+
+            var accountService = new BybitAccountService(httpClient, "key", "secret");
+            var result = await accountService.GetTransferableAmount("BTC");
+
+            Assert.NotNull(result);
+            Assert.Equal("4.5", result!.Result!.AvailableWithdrawal);
+            Assert.Equal("4.5", result.Result.AvailableWithdrawalMap!["BTC"]);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/AffiliateServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/AffiliateServiceEndpointTests.cs
@@ -1,0 +1,61 @@
+using bybit.net.api.ApiServiceImp;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class AffiliateServiceEndpointTests
+    {
+        [Fact]
+        public async Task GetAffiliateUserList_UsesDateFilters()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"list\":[],\"nextPageCursor\":\"16197\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/affiliate/aff-user-list" &&
+                        request.RequestUri.Query.Contains("startDate=2025-10-21") &&
+                        request.RequestUri.Query.Contains("endDate=2025-10-22")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAffiliateService(client, "key", "secret");
+            var result = await service.GetAffiliateUserList(startDate: "2025-10-21", endDate: "2025-10-22");
+
+            Assert.NotNull(result);
+            Assert.Equal("16197", result!.Result!.NextPageCursor);
+        }
+
+        [Fact]
+        public async Task GetAffiliateUserInfo_ReturnsTypedResult()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"uid\":\"1087997\",\"vipLevel\":\"5\",\"takerVol30Day\":\"17061.64983\",\"makerVol30Day\":\"10756.454142\",\"tradeVol30Day\":\"27818.103972\",\"depositAmount30Day\":\"0\",\"takerVol365Day\":\"1183752.53919162\",\"makerVol365Day\":\"44349.42819772\",\"tradeVol365Day\":\"1228101.96738934\",\"depositAmount365Day\":\"0\",\"totalWalletBalance\":\"4\",\"depositUpdateTime\":\"2026-02-04 00:00:00\",\"volUpdateTime\":\"2026-02-04 00:00:00\",\"KycLevel\":0,\"tradfiTradeVol30Day\":\"1828890.6352\",\"tradfiTradeVol365Day\":\"1828890.6352\",\"commissions30Day\":{\"USDT\":\"17.0461748\"},\"commissions365Day\":{\"USDT\":\"130.48078429\"}},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/user/aff-customer-info", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAffiliateService(client, "key", "secret");
+            var result = await service.GetAffiliateUserInfo("1087997");
+
+            Assert.NotNull(result);
+            Assert.Equal("5", result!.Result!.VipLevel);
+            Assert.Equal("130.48078429", result.Result.Commissions365Day!["USDT"]);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/AssetServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/AssetServiceEndpointTests.cs
@@ -1,0 +1,170 @@
+using bybit.net.api.ApiServiceImp;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Account;
+using bybit.net.api.Models.Asset;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class AssetServiceEndpointTests
+    {
+        [Fact]
+        public async Task GetTransferableCoin_UsesFromAccountType()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"list\":[\"BTC\"]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/asset/transfer/query-transfer-coin-list" &&
+                        request.RequestUri.Query.Contains("fromAccountType=UNIFIED") &&
+                        request.RequestUri.Query.Contains("toAccountType=FUND") &&
+                        !request.RequestUri.Query.Contains("accountType=")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.GetTransferableCoin(AccountType.Unified, AccountType.Fund);
+
+            Assert.NotNull(result);
+            Assert.Equal("BTC", result!.Result!.List![0]);
+        }
+
+        [Fact]
+        public async Task CreateInternalTransfer_UsesFromAccountType()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"transferId\":\"t1\",\"status\":\"SUCCESS\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/asset/transfer/inter-transfer" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"fromAccountType\":\"UNIFIED\"") &&
+                        !request.Content.ReadAsStringAsync().Result.Contains("\"accountType\":")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.CreateInternalTransfer(AccountType.Unified, AccountType.Fund, "USDT", "1", "t1");
+
+            Assert.NotNull(result);
+            Assert.Equal("SUCCESS", result!.Result!.Status);
+        }
+
+        [Fact]
+        public async Task GetInternalTransferRecords_UsesStatusQueryKey()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"list\":[],\"nextPageCursor\":\"\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/asset/transfer/query-inter-transfer-list" &&
+                        request.RequestUri.Query.Contains("status=SUCCESS") &&
+                        !request.RequestUri.Query.Contains("transferStatus=")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.GetInternalTransferRecords(transferStatus: TransferStatus.Success);
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.List!);
+        }
+
+        [Fact]
+        public async Task GetAssetAllowedDepositInfo_IsPublic()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"rows\":[],\"nextPageCursor\":\"\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/asset/deposit/query-allowed-list" &&
+                        !request.Headers.Contains("X-BAPI-API-KEY") &&
+                        !request.Headers.Contains("X-BAPI-SIGN")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client);
+            var result = await service.GetAssetAllowedDepositInfo();
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.Rows!);
+        }
+
+        [Fact]
+        public async Task GetFundingAccountTransactionHistory_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"nextPageCursor\":\"c1\",\"list\":[]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/asset/fundinghistory", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.GetFundingAccountTransactionHistory(limit: "1");
+
+            Assert.NotNull(result);
+            Assert.Equal("c1", result!.Result!.NextPageCursor);
+        }
+
+        [Fact]
+        public async Task GetFiatReferencePrice_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"symbol\":\"EUR-USDT\",\"fiat\":\"EUR\",\"crypto\":\"USDT\",\"timestamp\":\"1\",\"buys\":[],\"sells\":[]}}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/fiat/reference-price", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAssetService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.GetFiatReferencePrice("EUR-USDT");
+
+            Assert.NotNull(result);
+            Assert.Equal("EUR-USDT", result!.Result!.Symbol);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/BrokerServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/BrokerServiceEndpointTests.cs
@@ -1,0 +1,157 @@
+using bybit.net.api.ApiServiceImp;
+using bybit.net.api.Models.Broker;
+using bybit.net.api.Models.Lending;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class BrokerServiceEndpointTests
+    {
+        [Fact]
+        public async Task GetBrokerEarning_UsesCurrentRouteAndParameters()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"totalEarningCat\":{\"convert\":[{\"coin\":\"USDT\",\"earning\":\"1\"}]},\"details\":[],\"nextPageCursor\":\"c1\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/broker/earnings-info" &&
+                        request.RequestUri.Query.Contains("bizType=CONVERT") &&
+                        request.RequestUri.Query.Contains("begin=20240101") &&
+                        request.RequestUri.Query.Contains("end=20240107") &&
+                        request.RequestUri.Query.Contains("uid=12345") &&
+                        !request.RequestUri.Query.Contains("startTime=") &&
+                        !request.RequestUri.Query.Contains("endTime=")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitBrokerService(client, "key", "secret");
+            var result = await service.GetBrokerEarning(BizType.CONVERT, "20240101", "20240107", "12345");
+
+            Assert.NotNull(result);
+            Assert.Equal("c1", result!.Result!.NextPageCursor);
+            Assert.Equal("USDT", result.Result.TotalEarningCat!.Convert![0].Coin);
+        }
+
+        [Fact]
+        public async Task GetBrokerAccountInfo_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"subAcctQty\":\"2\",\"maxSubAcctQty\":\"20\",\"baseFeeRebateRate\":{\"spot\":\"10.0%\",\"derivatives\":\"10.0%\"},\"markupFeeRebateRate\":{\"spot\":\"6.00%\",\"derivatives\":\"9.00%\",\"convert\":\"3.00%\"},\"ts\":\"1701395633402\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/broker/account-info", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitBrokerService(client, "key", "secret");
+            var result = await service.GetBrokerAccountInfo();
+
+            Assert.NotNull(result);
+            Assert.Equal("20", result!.Result!.MaxSubAcctQty);
+            Assert.Equal("3.00%", result.Result.MarkupFeeRebateRate!.Convert);
+        }
+
+        [Fact]
+        public async Task SetBrokerRateLimit_UsesExpectedPayload()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"result\":[{\"uids\":\"290118\",\"bizType\":\"SPOT\",\"rate\":600,\"success\":true,\"msg\":\"API limit updated successfully\"}]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/broker/apilimit/set" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"uids\":\"290118\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"bizType\":\"SPOT\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"rate\":600")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitBrokerService(client, "key", "secret");
+            var result = await service.SetBrokerRateLimit(new List<BrokerRateLimitRequestItem>
+            {
+                new BrokerRateLimitRequestItem
+                {
+                    Uids = "290118",
+                    BizType = BizType.SPOT,
+                    Rate = 600
+                }
+            });
+
+            Assert.NotNull(result);
+            Assert.True(result!.Result!.Result![0].Success);
+        }
+
+        [Fact]
+        public async Task GetBrokerVoucherSpec_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"id\":\"80209\",\"coin\":\"USDT\",\"amountUnit\":\"AWARD_AMOUNT_UNIT_USD\",\"productLine\":\"PRODUCT_LINE_CONTRACT\",\"subProductLine\":\"SUB_PRODUCT_LINE_CONTRACT_DEFAULT\",\"totalAmount\":\"10000\",\"usedAmount\":\"100\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/broker/award/info", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitBrokerService(client, "key", "secret");
+            var result = await service.GetBrokerVoucherSpec("80209");
+
+            Assert.NotNull(result);
+            Assert.Equal("USDT", result!.Result!.Coin);
+        }
+
+        [Fact]
+        public async Task IssueBrokerVoucher_UsesExpectedPayload()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/broker/award/distribute-award" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"accountId\":\"2846381\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"awardId\":\"123456\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"brokerId\":\"v-28478\"")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitBrokerService(client, "key", "secret");
+            var result = await service.IssueBrokerVoucher("2846381", "123456", "award-001", "100", "v-28478");
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result!.RetCode);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/EarnServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/EarnServiceEndpointTests.cs
@@ -1,0 +1,170 @@
+using bybit.net.api.ApiServiceImp;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class EarnServiceEndpointTests
+    {
+        [Fact]
+        public async Task GetEarnOrderHistory_UsesCurrentOptionalParameters()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"list\":[],\"nextPageCursor\":\"c1\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/earn/order" &&
+                        request.RequestUri.Query.Contains("category=OnChain") &&
+                        request.RequestUri.Query.Contains("productId=8") &&
+                        request.RequestUri.Query.Contains("startTime=1") &&
+                        request.RequestUri.Query.Contains("endTime=2") &&
+                        request.RequestUri.Query.Contains("limit=10") &&
+                        request.RequestUri.Query.Contains("cursor=abc")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.GetEarnOrderHistory("OnChain", productId: "8", startTime: 1, endTime: 2, limit: 10, cursor: "abc");
+
+            Assert.NotNull(result);
+            Assert.Equal("c1", result!.Result!.NextPageCursor);
+        }
+
+        [Fact]
+        public async Task GetEarnAprHistory_IsPublic()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"list\":[{\"timestamp\":\"1773705600000\",\"apr\":\"15%\"}]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/earn/apr-history" &&
+                        !request.Headers.Contains("X-BAPI-API-KEY") &&
+                        !request.Headers.Contains("X-BAPI-SIGN")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client);
+            var result = await service.GetEarnAprHistory("OnChain", "8");
+
+            Assert.NotNull(result);
+            Assert.Equal("15%", result!.Result!.List![0].Apr);
+        }
+
+        [Fact]
+        public async Task PlaceFixedTermOrder_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"orderId\":\"o1\",\"orderLinkId\":\"link1\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/earn/fixed-term/place-order", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.PlaceFixedTermOrder("724", "FixedTermSaving", "USDT", "201", "FUND", "usdt-fixdearn-001");
+
+            Assert.NotNull(result);
+            Assert.Equal("o1", result!.Result!.OrderId);
+        }
+
+        [Fact]
+        public async Task SetFixedTermAutoInvest_UsesExpectedPayload()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/earn/fixed-term/position/auto-invest" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"positionId\":\"19454\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"status\":\"Enable\"")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client, apiKey: "key", apiSecret: "secret");
+            var result = await service.SetFixedTermAutoInvest("23", "FundPool", "19454", "Enable");
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result!.RetCode);
+        }
+
+        [Fact]
+        public async Task GetTokenProduct_IsPublic()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"productId\":\"1\",\"coin\":\"BYUSDT\",\"mintFeeRateE8\":\"0\",\"redeemFeeRateE8\":\"100000\",\"minInvestment\":\"1\",\"userHolding\":\"\",\"leftQuota\":\"\",\"canMint\":false,\"savingsBalance\":\"\",\"aprE8\":\"60000000\",\"bonusAprE8\":\"0\",\"bonusMaxAmount\":\"\",\"baseCoinPrecision\":4,\"tokenPrecision\":4},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/earn/token/product" &&
+                        !request.Headers.Contains("X-BAPI-API-KEY") &&
+                        !request.Headers.Contains("X-BAPI-SIGN")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client);
+            var result = await service.GetTokenProduct("BYUSDT");
+
+            Assert.NotNull(result);
+            Assert.Equal("BYUSDT", result!.Result!.Coin);
+        }
+
+        [Fact]
+        public async Task GetTokenHistoryApr_UsesExpectedPath()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"list\":[{\"timestamp\":\"1774569600\",\"aprE8\":\"2000000\"}]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/earn/token/history-apr", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitEarnService(client);
+            var result = await service.GetTokenHistoryApr("BYUSDT", 1);
+
+            Assert.NotNull(result);
+            Assert.Equal("2000000", result!.Result!.List![0].AprE8);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/LendingServiceEndpointTests.cs
+++ b/Tests/bybit.api.test/Tests/LendingServiceEndpointTests.cs
@@ -1,0 +1,153 @@
+using bybit.net.api.ApiServiceImp;
+using bybit.net.api.Models.Lending;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class LendingServiceEndpointTests
+    {
+        [Fact]
+        public async Task GetInsLoanInfo_IsPublic()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"marginProductInfo\":[]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/ins-loan/product-infos" &&
+                        !request.Headers.Contains("X-BAPI-API-KEY") &&
+                        !request.Headers.Contains("X-BAPI-SIGN")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client);
+            var result = await service.GetInsLoanInfo();
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.MarginProductInfo!);
+        }
+
+        [Fact]
+        public async Task GetInsLoanOrders_UsesCurrentRoute()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"loanInfo\":[]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/ins-loan/loan-order", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client, "key", "secret");
+            var result = await service.GetInsLoanOrders(limit: 10);
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.LoanInfo!);
+        }
+
+        [Fact]
+        public async Task GetInsLoanRepayOrders_UsesCurrentRoute()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"repayInfo\":[]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/ins-loan/repaid-history", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client, "key", "secret");
+            var result = await service.GetInsLoanRepayOrders(limit: 100);
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.RepayInfo!);
+        }
+
+        [Fact]
+        public async Task RepayInsLoan_UsesExpectedPayload()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"success\",\"result\":{\"repayOrderStatus\":\"P\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/ins-loan/repay-loan" &&
+                        request.Content != null &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"token\":\"USDT\"") &&
+                        request.Content.ReadAsStringAsync().Result.Contains("\"quantity\":\"500000\"")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client, "key", "secret");
+            var result = await service.RepayInsLoan("USDT", "500000");
+
+            Assert.NotNull(result);
+            Assert.Equal("P", result!.Result!.RepayOrderStatus);
+        }
+
+        [Fact]
+        public async Task C2CCancelRedeem_UsesRouteWithoutLeadingSpace()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"orderId\":\"1\",\"serialNo\":\"s1\",\"updatedTime\":\"2\"},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/lending/redeem-cancel", HttpMethod.Post)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client, "key", "secret");
+            var result = await service.C2CCancelRedeem(orderId: "1");
+
+            Assert.NotNull(result);
+            Assert.Equal("1", result!.Result!.OrderId);
+        }
+
+        [Fact]
+        public async Task GetC2CLendingOrders_UsesHistoryOrderRoute()
+        {
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"list\":[]},\"time\":1}";
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .SetupSendAsync("/v5/lending/history-order", HttpMethod.Get)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitLendingService(client, "key", "secret");
+            var result = await service.GetC2CLendingOrders(orderType: LendingOrderType.DEPOSIT);
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Result!.List!);
+        }
+    }
+}

--- a/Tests/bybit.api.test/Tests/MarketDataTest.cs
+++ b/Tests/bybit.api.test/Tests/MarketDataTest.cs
@@ -1,4 +1,6 @@
 using bybit.net.api.ApiServiceImp;
+using bybit.net.api.Models;
+using bybit.net.api.Models.Market;
 using Moq;
 using Moq.Protected;
 using System.Net;
@@ -12,7 +14,7 @@ namespace bybit.api.test.Tests
         [Fact]
         public async Task CheckServerTime_ResponseAsync()
         {
-            var responseContent = "{\"timeSecond\":1499827319559}";
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"OK\",\"result\":{\"timeSecond\":\"1499827319\",\"timeNano\":\"1499827319559000000\"},\"retExtInfo\":{},\"time\":1499827319559}";
             var mockMessageHandler = new Mock<HttpMessageHandler>();
             mockMessageHandler.Protected()
                 .SetupSendAsync("/v5/market/time", HttpMethod.Get)
@@ -31,7 +33,8 @@ namespace bybit.api.test.Tests
 
             var result = await market.CheckServerTime();
 
-            Assert.Equal(responseContent, result);
+            Assert.Equal(0, result?.RetCode);
+            Assert.Equal("1499827319", result?.Result?.timeSecond);
         }
         #endregion
     }

--- a/Tests/bybit.api.test/Tests/P2PServiceSigningTests.cs
+++ b/Tests/bybit.api.test/Tests/P2PServiceSigningTests.cs
@@ -1,0 +1,109 @@
+using bybit.net.api.ApiServiceImp;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace bybit.api.test.Tests
+{
+    public class P2PServiceSigningTests
+    {
+        [Fact]
+        public async Task GetAllOrders_SignsExactJsonBody()
+        {
+            const string apiKey = "test-key";
+            const string apiSecret = "test-secret";
+            const string recvWindow = "5000";
+            var responseContent = "{\"ret_code\":0,\"ret_msg\":\"SUCCESS\",\"result\":{\"count\":0,\"items\":[]},\"ext_code\":\"\",\"ext_info\":{},\"time_now\":\"1\"}";
+            HttpRequestMessage? capturedRequest = null;
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post &&
+                        request.RequestUri!.AbsolutePath == "/v5/p2p/order/simplifyList"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) => capturedRequest = request)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitP2PService(client, apiKey, apiSecret, recvWindow: recvWindow);
+
+            var result = await service.GetAllOrders(1, 5);
+
+            Assert.NotNull(result);
+            Assert.NotNull(capturedRequest);
+            Assert.NotNull(capturedRequest!.Content);
+
+            var body = await capturedRequest.Content!.ReadAsStringAsync();
+            var timestamp = capturedRequest.Headers.GetValues("X-BAPI-TIMESTAMP").Single();
+            var signature = capturedRequest.Headers.GetValues("X-BAPI-SIGN").Single();
+            var expectedSignature = Sign($"{timestamp}{apiKey}{recvWindow}{body}", apiSecret);
+
+            Assert.Equal("{\"page\":1,\"size\":5}", body);
+            Assert.Equal(expectedSignature, signature);
+        }
+
+        [Fact]
+        public async Task SignedGet_SignsExactQueryString()
+        {
+            const string apiKey = "test-key";
+            const string apiSecret = "test-secret";
+            const string recvWindow = "5000";
+            var responseContent = "{\"retCode\":0,\"retMsg\":\"\",\"result\":{\"list\":[],\"nextPageCursor\":\"\"},\"time\":1}";
+            HttpRequestMessage? capturedRequest = null;
+
+            var handler = new Mock<HttpMessageHandler>();
+            handler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Get &&
+                        request.RequestUri!.AbsolutePath == "/v5/affiliate/aff-user-list"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, _) => capturedRequest = request)
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(responseContent),
+                });
+
+            var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.bybit.com") };
+            var service = new BybitAffiliateService(client, apiKey, apiSecret, recvWindow: recvWindow);
+
+            var result = await service.GetAffiliateUserList(
+                size: 10,
+                cursor: "abc",
+                needDeposit: true,
+                need30: true,
+                need365: false,
+                startDate: "2025-10-21",
+                endDate: "2025-10-22");
+
+            Assert.NotNull(result);
+            Assert.NotNull(capturedRequest);
+
+            var queryString = capturedRequest!.RequestUri!.Query.TrimStart('?');
+            var timestamp = capturedRequest.Headers.GetValues("X-BAPI-TIMESTAMP").Single();
+            var signature = capturedRequest.Headers.GetValues("X-BAPI-SIGN").Single();
+            var expectedSignature = Sign($"{timestamp}{apiKey}{recvWindow}{queryString}", apiSecret);
+
+            Assert.Equal("size=10&cursor=abc&needDeposit=True&need30=True&need365=False&startDate=2025-10-21&endDate=2025-10-22", queryString);
+            Assert.Equal(expectedSignature, signature);
+        }
+
+        private static string Sign(string data, string secret)
+        {
+            using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+            return BitConverter.ToString(hmac.ComputeHash(Encoding.UTF8.GetBytes(data))).Replace("-", "").ToLower();
+        }
+    }
+}

--- a/Tests/bybit.api.test/bybit.api.test.csproj
+++ b/Tests/bybit.api.test/bybit.api.test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,8 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## [1.3.0] - 2026-04-22

### Added
- Added `BybitAccountService.GetAccountInstrumentsInfo(...)` for `GET /v5/account/instruments-info`.
- Added `BybitAccountService.ManualRepayWithoutAssetConversion(...)` for `POST /v5/account/no-convert-repay`.
- Added `BybitAccountService.GetOptionAssetInfo()` for `GET /v5/account/option-asset-info`.
- Added `BybitAccountService.GetPayInfo(...)` for `GET /v5/account/pay-info`.
- Added `BybitAccountService.SetDeltaNeutralMode(...)` for `POST /v5/account/set-delta-mode`.
- Added `BybitAccountService.GetTradeInfoForAnalysis(...)` for `GET /v5/account/trade-info-for-analysis`.
- Added `BybitAccountService.GetTransferableAmount(...)` for `GET /v5/account/withdrawal`.
- Added `BybitAssetService.GetFundingAccountTransactionHistory(...)` for `GET /v5/asset/fundinghistory`.
- Added `BybitAssetService.GetPortfolioMarginInfo(...)` for `GET /v5/asset/portfolio-margin`.
- Added `BybitAssetService.GetTotalMembersAssets(...)` for `GET /v5/asset/total-members-assets`.
- Added `BybitAssetService.GetAssetOverview(...)` for `GET /v5/asset/asset-overview`.
- Added `BybitAssetService.GetWithdrawalAddressList(...)` for `GET /v5/asset/withdraw/query-address`.
- Added small balance convert methods for `GET /v5/asset/covert/small-balance-list`, `POST /v5/asset/covert/get-quote`, `POST /v5/asset/covert/small-balance-execute`, and `GET /v5/asset/covert/small-balance-history`.
- Added fiat convert methods for `GET /v5/fiat/balance-query`, `GET /v5/fiat/query-coin-list`, `POST /v5/fiat/quote-apply`, `POST /v5/fiat/trade-execute`, `GET /v5/fiat/trade-query`, `GET /v5/fiat/query-trade-history`, and `GET /v5/fiat/reference-price`.
- Added `BybitBrokerService.GetBrokerAccountInfo()` for `GET /v5/broker/account-info`.
- Added `BybitBrokerService.GetBrokerSubMemberDepositRecords(...)` for `GET /v5/broker/asset/query-sub-member-deposit-record`.
- Added `BybitBrokerService.GetBrokerAllRateLimits(...)` for `GET /v5/broker/apilimit/query-all`.
- Added `BybitBrokerService.GetBrokerRateLimitCap()` for `GET /v5/broker/apilimit/query-cap`.
- Added `BybitBrokerService.SetBrokerRateLimit(...)` for `POST /v5/broker/apilimit/set`.
- Added `BybitBrokerService.GetBrokerVoucherSpec(...)` for `POST /v5/broker/award/info`.
- Added `BybitBrokerService.IssueBrokerVoucher(...)` for `POST /v5/broker/award/distribute-award`.
- Added `BybitBrokerService.GetIssuedBrokerVoucher(...)` for `POST /v5/broker/award/distribution-record`.
- Added easy earn methods for `GET /v5/earn/apr-history`, `GET /v5/earn/hourly-yield`, `GET /v5/earn/yield`, and `POST /v5/earn/position/modify`.
- Added fixed-term earn methods for `GET /v5/earn/fixed-term/product`, `POST /v5/earn/fixed-term/place-order`, `GET /v5/earn/fixed-term/order`, `GET /v5/earn/fixed-term/position`, `POST /v5/earn/fixed-term/redeem`, and `POST /v5/earn/fixed-term/position/auto-invest`.
- Added token earn methods for `GET /v5/earn/token/product`, `POST /v5/earn/token/place-order`, `GET /v5/earn/token/order`, `GET /v5/earn/token/position`, `GET /v5/earn/token/yield`, `GET /v5/earn/token/hourly-yield`, and `GET /v5/earn/token/history-apr`.
- Added `BybitLendingService.RepayInsLoan(...)` for `POST /v5/ins-loan/repay-loan`.
- Added `BybitMarketDataService.GetRpiOrderbook(...)` for `GET /v5/market/rpi_orderbook`.
- Added `BybitMarketDataService.GetAdlAlert(...)` for `GET /v5/market/adlAlert`.
- Added `BybitMarketDataService.GetIndexPriceComponents(...)` for `GET /v5/market/index-price-components`.
- Added `BybitMarketDataService.GetFeeGroupInfo(...)` for `GET /v5/market/fee-group-info`.
- Added `BybitNewCryptoLoanService.GetMaxLoanAmount(...)` for `POST /v5/crypto-loan-common/max-loan`.
- Added `BybitNewCryptoLoanService.RenewFixedLoan(...)` for `POST /v5/crypto-loan-fixed/renew`.
- Added `BybitNewCryptoLoanService.GetRenewOrderInfoFixed(...)` for `GET /v5/crypto-loan-fixed/renew-info`.
- Added `BybitP2PService.ReviewSellerCancelOrderApply(...)` for `POST /v5/p2p/order/buyer/examine/sellerCancelOrderApply`.
- Added `BybitP2PService.UploadChatFile(...)` for `POST /v5/p2p/oss/upload_file`.
- Added `BybitRFQService.AcceptOtherQuote(...)` for `POST /v5/rfq/accept-other-quote`.
- Added Spot Margin UTA methods for currency data, coin state, position tiers, max borrowable amount, repayment available amount, auto repay mode, fixed-rate borrow, fixed-rate renew, fixed-rate order/contract info, and liability endpoints.
- Added `BybitSpreadTradingService.GetSpreadMaxOrderQty(...)` for `GET /v5/spread/max-qty`.
- Added lightweight `BybitAlphaService` coverage for the V5 Alpha trade endpoints.
- Added lightweight `BybitBotService` coverage for V5 spot grid, DCA, futures combo, futures grid, and futures martingale bot endpoints.
- Added typed account request models for manual repay and delta mode operations.
- Added typed affiliate response models for affiliate user list and affiliate user info endpoints.
- Added typed account response models for newly implemented account endpoints and updated account mutations.
- Added typed asset response models for transfer, funding, portfolio margin, withdrawal address, small balance convert, fiat convert, delivery, settlement, exchange record, and allowed deposit endpoints.
- Added typed broker response and request models for earnings, account info, subaccount deposits, rate limits, and voucher endpoints.
- Added typed earn response models for shared earn, fixed-term earn, and BYUSDT token earn endpoints.
- Added typed lending response models for institutional lending and legacy C2C lending endpoints.
- Added typed market response models for recent trades, open interest, insurance pool, delivery price, index price components, ADL alerts, and fee group info.
- Added typed new crypto loan request and response models for active common, flexible, and fixed crypto loan endpoints.
- Added typed P2P response models for active P2P ad, order, chat, account, and payment endpoints.
- Added typed position response models for active position endpoints.
- Added account endpoint tests covering new routes and request payload mapping.
- Added asset endpoint tests covering route selection, payload mapping, and public access behavior.
- Added broker endpoint tests covering current broker routes and request payload mapping.
- Added earn endpoint tests covering shared earn, fixed-term, and token endpoint routing and payload mapping.
- Added lending endpoint tests covering current OTC routes, public access behavior, and corrected legacy lending routes.
- Added affiliate endpoint tests covering the affiliate date-filter query mapping and typed response mapping.

### Changed
- Updated library, test, and example project target frameworks to .NET 10 LTS.
- Updated `BybitAccountService.SetAccountMarginMode(...)` to send the correct request field name `setMarginMode`.
- Updated `BybitAccountService.ManualRepay(...)` to support the documented `repaymentType` parameter.
- Updated `BybitAccountService.ManualBorrow(...)`, `ManualRepay(...)`, and `SetAccountMarginMode(...)` to return typed models instead of raw JSON strings.
- Updated `BybitAssetService.GetTransferableCoin(...)`, `CreateInternalTransfer(...)`, and `CreateUniversalTransfer(...)` to send `fromAccountType`.
- Updated `BybitAssetService.GetInternalTransferRecords(...)` and `GetUniversalTransferRecords(...)` to send `status` instead of `transferStatus`.
- Updated `BybitAssetService.GetAssetAllowedDepositInfo(...)` to use the public endpoint flow instead of signed authentication.
- Updated `BybitAssetService.GetDeliveryRecord(...)`, `GetCoinExchangeRecords(...)`, and `GetAssetUsdcSettlement(...)` to return typed response models.
- Updated `BybitBrokerService.GetBrokerEarning(...)` to use `GET /v5/broker/earnings-info` with `begin`, `end`, and `uid` instead of the obsolete `earning-record` route and `startTime`/`endTime` fields.
- Updated `BybitEarnService.GetProductInfo(...)`, `PlaceEarnOrder(...)`, `GetEarnOrderHistory(...)`, and `GetStakedPosition(...)` to return typed models instead of raw JSON strings.
- Updated `BybitEarnService.GetEarnOrderHistory(...)` to support the documented `productId`, `startTime`, `endTime`, `limit`, and `cursor` parameters.
- Updated `BybitEarnService` with public constructors so public earn endpoints can be used without API credentials.
- Updated `BybitLendingService.GetInsLoanOrders(...)` and `GetInsLoanRepayOrders(...)` to use the current OTC routes instead of the incorrect `ensure-tokens-convert` placeholder route.
- Updated `BybitLendingService.GetInsLoanInfo(...)` and `GetInsMarginCoinInfo(...)` to use the public endpoint flow and return typed models.
- Updated `BybitLendingService` legacy C2C methods to use typed models and corrected routes for `redeem-cancel` and `history-order`.
- Updated `BybitAffiliateService.GetAffiliateUserList(...)` to support the documented `startDate` and `endDate` parameters.
- Updated `BybitAffiliateService.GetAffiliateUserList(...)` and `GetAffiliateUserInfo(...)` to return typed models instead of raw JSON strings.
- Updated `BybitMarketDataService` public endpoints to return typed `GeneralResponse<T>` models instead of raw JSON strings.
- Updated `BybitMarketDataService.GetInstrumentInfo(...)` to support the documented `symbolType` parameter.
- Updated `BybitMarketDataService.GetMarketOrderbook(...)` to require the documented `symbol` parameter.
- Updated market kline methods to support omitted `category` where the V5 docs define a default.
- Updated `BybitMarketDataService.GetMarketHistoricalVolatility(...)` to support `quoteCoin` and the documented integer `period` request shape.
- Updated `BybitNewCryptoLoanService` with public constructors so public new crypto loan endpoints can be used without API credentials.
- Updated `BybitNewCryptoLoanService.BorrowFlexibleLoan(...)` to send documented `currency` and `amount` collateral fields.
- Updated `BybitNewCryptoLoanService.CreateBorrowOrderFixed(...)` to support the documented `repayType` parameter.
- Updated `BybitNewCryptoLoanService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
- Updated `BybitP2PService.GetAllOrders(...)` and `GetPendingOrders(...)` to send `side` as a single integer instead of an array.
- Updated `BybitP2PService` methods to return typed P2P response models instead of raw JSON strings.
- Updated signed REST transport to support multipart form-data requests.
- Updated `BybitPositionService.SwitchPositionMode(...)` to send the documented `mode` field.
- Updated `BybitPositionService.SetPositionTradingStop(...)` to send `positionIdx`, require `tpslMode`, and support `activePrice`.
- Updated `BybitPositionService.SetPositionAutoAddMargin(...)` to make `positionIdx` optional.
- Updated `BybitPositionService.GetMovePositionHistory(...)` and `GetClosedOptionsPositions(...)` timestamp parameters to use 64-bit values.
- Updated `BybitPositionService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
- Updated `BybitRateLimitService` methods to return typed `GeneralResponse<T>` models instead of raw JSON strings.
- Updated RFQ quote request legs to support the documented `price` field.
- Updated Spot Margin UTA switch-mode to use `POST`, corrected `SpotMarginMode` values, changed status lookup to `GET`, and added optional `currency` support to set leverage.

### Notes
- `GetContractTransactionLogClassic(...)` remains in the SDK because the local documentation marks it as legacy rather than fully removed.
- Removed the stale `GetAssetDeliveryRecords(...)` implementation that pointed to the coin exchange history route instead of the active delivery endpoint.
- Removed the abandoned `BybitPositionService.SwitchPositionMargin(...)` method for `POST /v5/position/switch-isolated`.
